### PR TITLE
Data loading functions for tfrecord and waveform data formats

### DIFF
--- a/R/scorch_read_wfdb_file.R
+++ b/R/scorch_read_wfdb_file.R
@@ -589,6 +589,7 @@ create_scorch_wfdb_class <- function(obj) {
 #'   first \code{n} columns. If \code{x$success} is \code{FALSE}, returns
 #'   \code{NULL} with a message.
 #'
+#' @importFrom utils head
 #' @export
 #'
 #' @examples

--- a/R/scorch_tfrecord.R
+++ b/R/scorch_tfrecord.R
@@ -380,6 +380,7 @@ create_scorch_tfrecord_class <- function(obj) {
 #'
 #' @returns A list containing the first elements of the input and output tensors.
 #'
+#' @importFrom utils head
 #' @export
 #'
 #' @examples


### PR DESCRIPTION
Updates the previous `scorch_tfrecord` function and adds the new `scorch_read_wfdb_file` function. 

- `scorch_tfrecord()` reads TFRecord files (TensorFlow's binary format) into torch tensors, enabling interoperability with TensorFlow-based data pipelines. Includes a custom `S3 class` with print and head methods.

- `scorch_read_wfdb_file()` reads WFDB-format signal files (.dat + .hea) used in PhysioNet databases like MIMIC-IV. Parses header metadata (leads, sampling frequency, gain, baseline) and reads binary signal data into a structured R object. Includes print and head methods for the scorch_wfdb class.