### PR TITLE
Replace sequential architecture with graph-based model construction

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,9 +12,7 @@ RoxygenNote: 7.3.2
 Imports: 
     coro,
     crayon,
-    glue,
     purrr,
-    stringr,
     tibble,
     torch,
     utils

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,9 @@ Imports:
     coro,
     crayon,
     glue,
+    purrr,
     stringr,
+    tibble,
     torch,
     utils
 Config/Needs/website: rmarkdown

--- a/R/compile_scorch.R
+++ b/R/compile_scorch.R
@@ -79,6 +79,7 @@ utils::globalVariables("self")
 #'     optimizer_params = list(lr = 1e-3)
 #'   )
 #' }
+#' @import torch
 #'
 #' @family model construction
 #'

--- a/R/compile_scorch.R
+++ b/R/compile_scorch.R
@@ -1,194 +1,167 @@
 #===============================================================================
-# COMPILE SCORCH MODEL
+# FUNCTION TO COMPILE A SCORCH MODEL
 #===============================================================================
 
-utils::globalVariables(c("self", "aux"))
+utils::globalVariables("self")
 
 #=== MAIN FUNCTION =============================================================
 
 #' Compile a Scorch Model
 #'
-#' @param sm A scorch model architecture
+#' @description
+#' Compiles a Scorch model by traversing the graph topology to build a
+#' \code{torch::nn_module}, then attaches an optimizer and loss function.
+#' After compilation, the model is ready for training with
+#' \code{\link{fit_scorch}}.
 #'
-#' @param init_fn An optional function for initializing the model's parameters.
-#' This function takes the model and additional arguments passed via `...`.
+#' @param sm A \code{scorch_model} object built with
+#'   \code{\link{initiate_scorch}}, \code{\link{scorch_input}},
+#'   \code{\link{scorch_layer}}, and \code{\link{scorch_output}}.
 #'
-#' @param forward_fn An optional function for customizing the forward pass of
-#' the model. This function takes the model, input data, and additional
-#' arguments passed via `...`.
+#' @param loss_fn A loss function or a named list of loss functions.
+#'   For single-output models, pass a single loss (e.g.,
+#'   \code{torch::nn_mse_loss()}). For multi-output models, pass a
+#'   named list with one entry per output node (e.g.,
+#'   \code{list(reg_head = nn_mse_loss(), cls_head = nn_cross_entropy_loss())}).
 #'
-#' @param ... Additional arguments passed to the `init_fn` and `forward_fn`.
+#' @param optimizer_fn An optimizer constructor function (e.g.,
+#'   \code{torch::optim_adam}, \code{torch::optim_sgd}). Not an
+#'   instantiated optimizer -- the constructor is called internally
+#'   with the model parameters.
 #'
-#' @return A list containing:
-#' \describe{
-#'   \item{nn_model}{The compiled `scorch` model object, ready for training.}
-#'   \item{dl}{The associated scorch dataloader object.}
-#' }
+#' @param optimizer_params A named list of optimizer parameters (e.g.,
+#'   \code{list(lr = 1e-3, weight_decay = 1e-4)}). Passed to
+#'   \code{optimizer_fn} along with the model parameters.
 #'
-#' @import torch
+#' @returns The same \code{scorch_model} object with the following
+#'   fields populated:
+#'   \describe{
+#'     \item{\code{nn_model}}{The compiled \code{torch::nn_module}.}
+#'     \item{\code{optimizer}}{The instantiated optimizer.}
+#'     \item{\code{loss_fn}}{The loss function (or named list).}
+#'     \item{\code{compiled}}{Set to \code{TRUE}.}
+#'   }
+#'
+#' @details
+#' Compilation works by:
+#'   \enumerate{
+#'     \item Registering every graph node as a sub-module of a new
+#'       \code{nn_module}. This enables torch to track all learnable
+#'       parameters.
+#'     \item Building a \code{forward()} method that traverses the
+#'       graph in row order, passing each node its upstream tensors
+#'       via a name-lookup environment.
+#'     \item Instantiating the optimizer with the model parameters.
+#'   }
+#'
+#' The graph must have at least one input (\code{\link{scorch_input}})
+#' and one output (\code{\link{scorch_output}}) declared before
+#' compilation.
 #'
 #' @examples
+#' \dontrun{
+#' # Single-output model
+#' model <- model |>
+#'   compile_scorch(
+#'     loss_fn          = torch::nn_mse_loss(),
+#'     optimizer_fn     = torch::optim_adam,
+#'     optimizer_params = list(lr = 1e-3)
+#'   )
 #'
-#' input  <- mtcars |> as.matrix() |> torch::torch_tensor()
+#' # Multi-output model
+#' model <- model |>
+#'   compile_scorch(
+#'     loss_fn = list(
+#'       reg_head = torch::nn_mse_loss(),
+#'       cls_head = torch::nn_cross_entropy_loss()
+#'     ),
+#'     optimizer_fn     = torch::optim_adam,
+#'     optimizer_params = list(lr = 1e-3)
+#'   )
+#' }
 #'
-#' output <- mtcars[, 1:2] |> as.matrix() |> torch::torch_tensor()
-#'
-#' dl <- scorch_create_dataloader(input, output, batch_size = 2)
-#'
-#' scorch_model <- dl |> initiate_scorch() |>
-#'
-#'   scorch_layer("linear", 11, 5) |>
-#'
-#'   scorch_layer("linear", 5, 2) |>
-#'
-#'   compile_scorch()
+#' @family model construction
 #'
 #' @export
 
-compile_scorch <- function(sm, init_fn = NULL, forward_fn = NULL, ...) {
+compile_scorch <- function(sm,
+                           loss_fn          = torch::nn_mse_loss(),
+                           optimizer_fn     = torch::optim_adam,
+                           optimizer_params = list(lr = 1e-3)) {
 
-  model <- nn_module(
+  graph   <- sm$graph
+  inputs  <- sm$inputs
+  outputs <- sm$outputs
 
-    initialize = function(sm) {
+  #- Build the nn_module by registering all graph nodes as sub-modules
+  #- and defining the forward pass as a graph traversal.
 
-      n_layer = length(sm$scorch_architecture) / 2
+  mod <- torch::nn_module(
 
-      layer_types = sm$scorch_architecture[2 * (1:n_layer)] |> unlist()
+    initialize = function() {
 
-      layer_index = which(layer_types == "layer") * 2 - 1
+      for (i in seq_len(nrow(graph))) {
 
-      func_index = which(layer_types == "function") * 2 - 1
-
-      modules = nn_module_list(sm$scorch_architecture[layer_index])
-
-      self$modules = modules
-
-      self$functions = sm$scorch_architecture[func_index]
-
-      if (!is.null(init_fn)) {
-
-        init_fn(self, ...)
+        self[[graph$name[i]]] <- graph$module[[i]]
       }
     },
 
-    forward = function(input, ...) {
+    forward = function(...) {
 
-      if (!is.null(forward_fn)) {
+      args <- list(...)
 
-        input <- forward_fn(self, input, ...)
+      env  <- new.env(parent = emptyenv())
+
+      #- Assign inputs to the environment.
+
+      if (length(inputs) == 1) {
+
+        env[[inputs]] <- args[[1]]
+
+      } else {
+
+        for (nm in names(args)) env[[nm]] <- args[[nm]]
       }
 
-      n_layer = length(sm$scorch_architecture) / 2
+      #- Compute each node in graph order.
 
-      layer_types = sm$scorch_architecture[2 * (1:n_layer)] |> unlist()
+      for (i in seq_len(nrow(graph))) {
 
-      layer_index = which(layer_types == "layer")
+        node    <- graph[i, ]
 
-      output = input
+        in_vals <- lapply(node$inputs[[1]], function(nm) env[[nm]])
 
-      i_layer = i_function = 1
+        out     <- do.call(self[[node$name]], in_vals)
 
-      for(i in 1:n_layer) {
-
-        if(i %in% layer_index) {
-
-          output = self$modules[[i_layer]](output)
-
-          i_layer = i_layer + 1
-
-        } else {
-
-          output = self$functions[[i_function]](output)
-
-          i_function = i_function + 1
-        }
+        env[[node$name]] <- out
       }
 
-      return(output)
+      #- Return outputs.
+
+      if (length(outputs) == 1) {
+
+        env[[outputs]]
+
+      } else {
+
+        purrr::map(outputs, ~ env[[.x]])
+      }
     }
   )
 
-  return(list(nn_model = sm |> model(), dl = sm$dl))
-}
+  #- Instantiate the module, optimizer, and attach everything.
 
-#=== HELPERS ===================================================================
+  sm$nn_model  <- mod()
 
-#--- COMPILED SCORCH MODEL CLASS -----------------------------------------------
+  sm$optimizer <- do.call(optimizer_fn,
+                          c(list(params = sm$nn_model$parameters),
+                            optimizer_params))
 
-#' Create a Compiled Scorch Model Class
-#'
-#' @description
-#' This function creates an object of class 'compiled_scorch_model' by
-#' appending it to the existing classes of the input object.
-#'
-#' @param obj An object to be converted to a compiled scorch model.
-#'
-#' @return The input object with the class attribute set to include
-#' 'compiled_scorch_model'.
-#'
-#' @export
-#'
-#' @examples
-#'
-#' model <- list(children = list(modules = "module details"))
-#'
-#' compiled_model <- create_scorch_nn_module_class(model)
-#'
-#' class(compiled_model)
+  sm$loss_fn   <- loss_fn
 
-create_scorch_nn_module_class <- function(obj) {
+  sm$compiled  <- TRUE
 
-  class(obj) <- c("compiled_scorch_model", class(obj))
-
-  return(obj)
-}
-
-#--- PRINT METHOD --------------------------------------------------------------
-
-#' Print Method for Scorch Neural Network Module
-#'
-#' @description
-#' This function defines the print method for objects of class
-#' 'scorch_nn_module'.
-#'
-#' @param x An object of class 'scorch_nn_module'.
-#'
-#' @param ... Additional arguments to be passed to the print function.
-#'
-#' @export
-#'
-#' @examples
-#'
-#' model <- list(children = list(modules = "module details"))
-#'
-#' model$children$modules <- "modules: 123\nlayer1 #64\nlayer2 #32"
-#'
-#' class(model) <- c("scorch_nn_module", class(model))
-#'
-#' print(model)
-
-print.scorch_nn_module <- function(x, ...) {
-
-  output <- utils::capture.output(x$children$modules)
-
-  n_param <- stringr::str_extract(output[1], "\\d+")
-
-  n_params_layer <- gsub("#", "", stringr::str_extract(
-
-    output[grep("#", output)], "#\\d+"))
-
-  cat(glue::glue("This scorch_nn_module has ",
-
-    "{crayon::red(n_param)} parameters \n\n"))
-
-  cat("\n\n")
-
-  for(i in 1:length(n_params_layer)) {
-
-    cat(glue::glue(" * Layer {i} has ", "
-
-      {crayon::red(n_params_layer[i])} parameters\n\n"))
-  }
+  sm
 }
 
 #=== END =======================================================================

--- a/R/create_dataloader.R
+++ b/R/create_dataloader.R
@@ -1,261 +1,236 @@
 #===============================================================================
-# FUNCTIONS FOR CREATING DATALOADERS
+# FUNCTION TO CREATE A SCORCH DATALOADER
 #===============================================================================
 
 #=== MAIN FUNCTION =============================================================
 
-#' Create a New Dataloader for Building a Scorch Model
+#' Create a Scorch DataLoader for Multi-Input / Multi-Output Models
 #'
 #' @description
-#' This function creates a dataloader for building a scorch model from the
-#' given input and output tensors.
+#' Builds a \code{torch::dataloader} from input and output data. Accepts
+#' bare tensors, R arrays, or named lists for multi-input and
+#' multi-output architectures. Inputs are converted to float and outputs
+#' are converted to the appropriate dtype (long for classification,
+#' float for regression).
 #'
-#' @param input A tensor representing the input data (usually your predictors,
-#' first dimensions is index).
+#' @param input A torch tensor, R array, or named list thereof. For
+#'   multi-input models, pass a named list with one element per input
+#'   stream (e.g., \code{list(a = tensor_a, b = tensor_b)}).
 #'
-#' @param output A tensor representing the output data (usually what you are
-#' predicting, first dimension is index).
+#' @param output A torch tensor, R array, or named list thereof. For
+#'   multi-output models, pass a named list with one element per output
+#'   head.
 #'
-#' @param name A character string representing the name of the dataloader.
-#' Default is "dl".
+#' @param batch_size Integer. Batch size (default 32).
 #'
-#' @param batch_size An integer specifying the batch size. Default is 32.
+#' @param shuffle Logical. Shuffle each epoch? (default \code{TRUE}).
 #'
-#' @param shuffle A logical value indicating whether to shuffle the data.
-#' Default is TRUE.
+#' @param num_workers Integer. Number of worker processes for data
+#'   loading (default 0).
 #'
-#' @return The dataloader with the specified batch size as a scorch_dataloader.
+#' @param pin_memory Logical. Pin memory for faster GPU transfer
+#'   (default \code{FALSE}).
 #'
-#' @export
+#' @param ... Additional arguments passed to \code{torch::dataloader()}.
 #'
-#' @examples
+#' @returns A \code{torch::dataloader} yielding batches of the form
+#'   \code{list(input = <named list>, output = <named list>)}.
 #'
-#' input  <- mtcars |> as.matrix() |> torch::torch_tensor()
+#' @details
+#' Type conversion is handled automatically:
+#'   \describe{
+#'     \item{Inputs}{Cast to \code{torch_float()}. 3-D tensors (N, H, W)
+#'       gain a channel dimension (N, 1, H, W). 1-D tensors (N) become
+#'       (N, 1).}
+#'     \item{Outputs}{Integer vectors and 1-D long tensors are kept as
+#'       \code{torch_long()} for classification. Float vectors and tensors
+#'       are kept as \code{torch_float()} for regression. 1-D float
+#'       tensors are unsqueezed to (N, 1).}
+#'   }
 #'
-#' output <- mtcars |> as.matrix() |> torch::torch_tensor()
-#'
-#' dl <- scorch_create_dataloader(input, output, batch_size = 2)
-
-scorch_create_dataloader <- function(input, output,
-
-  name = "dl", batch_size = 32, shuffle = TRUE){
-
-  ## Check Input Arguments
-
-  stopifnot("`input` must be a tensor"  = ("torch_tensor" %in% class(input)))
-
-  stopifnot("`output` must be a tensor" = ("torch_tensor" %in% class(output)))
-
-  ## Set Up Dataset Creator Function
-
-  create_dataset <- torch::dataset(
-
-    name = name,
-
-    initialize = function(input, output, aux) {
-
-      self$input = input
-
-      self$output = output
-    },
-
-    .getitem = function(index) {
-
-      list(
-
-        input = self$input[index],
-
-        output = self$output[index])
-    },
-
-    .length = function() {
-
-      self$input$shape[1]
-    }
-  )
-
-  ## Create Dataset
-
-  ds <- create_dataset(input, output, aux)
-
-  ## Create the Dataloader
-
-  dl <- torch::dataloader(ds, batch_size = batch_size, shuffle = shuffle)
-
-  dl <- create_scorch_dataloader_class(dl)
-
-  return(dl)
-}
-
-#=== UTILITY FUNCTIONS =========================================================
-
-#--- SCORCH DATALOADER CLASS ---------------------------------------------------
-
-#' Create a Scorch Dataloader Class
-#'
-#' @description
-#' This function adds the class 'scorch_dataloader' to a given dataloader
-#' object.
-#'
-#' @param dl A dataloader object.
-#'
-#' @return The input dataloader object with the class attribute set to include
-#' 'scorch_dataloader'.
-#'
-#' @export
+#' Bare (non-list) inputs and outputs are wrapped in a single-element
+#' named list automatically.
 #'
 #' @examples
+#' \dontrun{
+#' # Single input / single output
+#' dl <- scorch_create_dataloader(
+#'   input  = torch::torch_randn(100, 10),
+#'   output = torch::torch_randn(100, 1),
+#'   batch_size = 32
+#' )
 #'
-#' input  <- mtcars |> as.matrix() |> torch::torch_tensor()
+#' # Multi-input for fusion models
+#' dl <- scorch_create_dataloader(
+#'   input  = list(a = tensor_a, b = tensor_b),
+#'   output = labels,
+#'   batch_size = 16
+#' )
+#' }
 #'
-#' output <- mtcars |> as.matrix() |> torch::torch_tensor()
-#'
-#' dl <- scorch_create_dataloader(input, output, batch_size = 2)
-#'
-#' scorch_dataloader <- create_scorch_dataloader_class(dl)
-#'
-#' class(scorch_dataloader)
-
-create_scorch_dataloader_class <- function(dl) {
-
-  tmp <- dl
-
-  class(tmp) <- c("scorch_dataloader", class(dl))
-
-  return(tmp)
-}
-
-#--- CALCULATE TENSOR DIMENSIONS -----------------------------------------------
-
-#' Calculate Dimensions of a Tensor
-#'
-#' @description
-#' Calculates the dimensions of a given tensor, returning a formatted string.
-#'
-#' @param tensor A tensor object.
-#'
-#' @return A string representing the dimensions of the tensor, excluding the
-#' batch dimension. If the tensor has only one dimension, returns 1.
+#' @family data loading
 #'
 #' @export
-#'
-#' @examples
-#'
-#' input <- mtcars |> as.matrix() |> torch::torch_tensor()
-#'
-#' calc_dim(input)
 
-calc_dim <- function(tensor) {
+scorch_create_dataloader <- function(input,
+                                     output,
+                                     batch_size  = 32,
+                                     shuffle     = TRUE,
+                                     num_workers = 0,
+                                     pin_memory  = FALSE,
+                                     ...) {
 
-  ndim = length(dim(tensor))
+  #- Wrap bare tensors/arrays into named lists.
 
-  if(ndim == 1) {
+  if (!is.list(input) || inherits(input, "torch_tensor")) {
 
-    return(1)
-
-  } else {
-
-    return(paste0(dim(tensor)[-1], collapse = " "))
+    input <- list(input = input)
   }
-}
 
-#=== METHODS ===================================================================
+  if (!is.list(output) || inherits(output, "torch_tensor")) {
 
-#--- HEAD ----------------------------------------------------------------------
+    output <- list(output = output)
+  }
 
-#' @importFrom utils head
-#' @export
-utils::head
+  #- Convert inputs to float, add channel dims as needed.
 
-#' Head Method for Scorch Dataloader
-#'
-#' @description
-#' Defines the head method for objects of class 'scorch_dataloader', returning
-#' the first elements of the input and output data.
-#'
-#' @param x An object of class 'scorch_dataloader'.
-#'
-#' @param ... Additional arguments to be passed to the head function.
-#'
-#' @return A list containing the first elements of the input and output data
-#' from the dataloader.
-#'
-#' @export
-#'
-#' @examples
-#'
-#' input  <- mtcars |> as.matrix() |> torch::torch_tensor()
-#'
-#' output <- mtcars |> as.matrix() |> torch::torch_tensor()
-#'
-#' dl <- scorch_create_dataloader(input, output, batch_size = 2)
-#'
-#' head(dl)
+  make_input_tensor <- function(x) {
 
-head.scorch_dataloader <- function(x, ...) {
+    t <- if (inherits(x, "torch_tensor")) {
 
-  val <- x$.iter()$.next()
+      x
 
-  return(
+    } else {
 
-    list(input  = head(val$input,  ...),
+      torch::torch_tensor(x, dtype = torch::torch_float())
+    }
 
-         output = head(val$output, ...))
+    #- Cast any non-float to float.
+
+    if (t$dtype != torch::torch_float()) {
+
+      t <- t$to(dtype = torch::torch_float())
+    }
+
+    #- Unsqueeze channel dim for images/features.
+
+    if (t$dim() == 3L) {
+
+      t <- t$unsqueeze(2)  # (N, H, W) -> (N, 1, H, W)
+
+    } else if (t$dim() == 1L) {
+
+      t <- t$unsqueeze(2)  # (N) -> (N, 1)
+    }
+
+    t
+  }
+
+  #- Convert outputs to long or float appropriately.
+
+  make_output_tensor <- function(x) {
+
+    if (inherits(x, "torch_tensor")) {
+
+      t <- x
+
+    } else if (is.integer(x)) {
+
+      t <- torch::torch_tensor(x, dtype = torch::torch_long())
+
+    } else {
+
+      t <- torch::torch_tensor(x, dtype = torch::torch_float())
+    }
+
+    #- Classification: 1-D long stays (N).
+
+    if (t$dtype == torch::torch_long() && t$dim() == 1L) {
+
+      return(t)
+    }
+
+    #- Regression single-output: 1-D float -> (N, 1).
+
+    if (t$dtype == torch::torch_float() && t$dim() == 1L) {
+
+      return(t$unsqueeze(2))
+    }
+
+    #- Regression multi-output: multi-dim float stays.
+
+    if (t$dtype == torch::torch_float() && t$dim() > 1L) {
+
+      return(t)
+    }
+
+    #- Multi-dim long (accidental int matrix): cast to float.
+
+    if (t$dtype == torch::torch_long() && t$dim() > 1L) {
+
+      return(t$to(dtype = torch::torch_float()))
+    }
+
+    t
+  }
+
+  #- Apply conversions.
+
+  input  <- lapply(input, make_input_tensor)
+
+  output <- lapply(output, make_output_tensor)
+
+  #- Define dataset.
+
+  scorch_ds <- torch::dataset(
+
+    name = "scorch_dataset",
+
+    initialize = function(input, output) {
+
+      self$input  <- input
+
+      self$output <- output
+
+      self$n <- input[[1]]$size()[1]
+    },
+
+    .getitem = function(i) {
+
+      slice <- function(x) {
+
+        if (x$dim() == 1L) {
+
+          x[i]
+
+        } else {
+
+          x$narrow(1, i, 1)$squeeze(1)
+        }
+      }
+
+      inp <- lapply(self$input, slice)
+
+      out <- lapply(self$output, slice)
+
+      list(input = inp, output = out)
+    },
+
+    .length = function() self$n
   )
-}
 
-#--- PRINT ---------------------------------------------------------------------
+  ds <- scorch_ds(input = input, output = output)
 
-#' Print Method for Scorch Dataloader
-#'
-#' @description
-#' Defines the print method for objects of class 'scorch_dataloader', providing
-#' a summary of its features.
-#'
-#' @param x An object of class 'scorch_dataloader'.
-#'
-#' @param ... Additional arguments to be passed to the print function.
-#'
-#' @return NULL. This function is called for its side effect of printing
-#' information about the dataloader.
-#'
-#' @export
-#'
-#' @examples
-#'
-#' input  <- mtcars |> as.matrix() |> torch::torch_tensor()
-#'
-#' output <- mtcars |> as.matrix() |> torch::torch_tensor()
-#'
-#' dl <- scorch_create_dataloader(input, output)
-#'
-#' print(dl)
+  #- Build dataloader.
 
-print.scorch_dataloader <- function(x, ...) {
-
-  cat("This is a dataloader object with features:\n")
-
-  cat(paste0(" * Batch size: ",
-
-    crayon::red(x$batch_size)))
-
-  cat("\n")
-
-  cat(paste0(" * Number of batches: ",
-
-    crayon::red(x$.length())))
-
-  cat("\n")
-
-  cat(paste0(" * Dimension of input tensors: ",
-
-    crayon::red(calc_dim(x$.iter()$.next()$input))))
-
-  cat("\n")
-
-  cat(paste0(" * Dimension of output tensors: ",
-
-    crayon::red(calc_dim(x$.iter()$.next()$output))))
+  torch::dataloader(
+    ds,
+    batch_size  = batch_size,
+    shuffle     = shuffle,
+    num_workers = num_workers,
+    pin_memory  = pin_memory,
+    ...
+  )
 }
 
 #=== END =======================================================================

--- a/R/fit_scorch.R
+++ b/R/fit_scorch.R
@@ -1,169 +1,235 @@
 #===============================================================================
-# FUNCTIONS FOR FITTING A SCORCH MODEL
+# FUNCTION TO FIT A SCORCH MODEL
 #===============================================================================
 
 #=== MAIN FUNCTION =============================================================
 
 #' Fit a Scorch Model
 #'
-#' @param scorch_model A scorch model object
+#' @description
+#' Trains a compiled Scorch model using the attached dataloader,
+#' optimizer, and loss function. Supports single-output and
+#' multi-output (multi-head) architectures.
 #'
-#' @param loss A loss function from the torch package.
-#' Default is `nn_mse_loss`.
+#' @param sm A compiled \code{scorch_model} object. Must have been
+#'   processed by \code{\link{compile_scorch}} before fitting.
 #'
-#' @param loss_params A list of parameters to pass to the loss function.
-#' Default is `list(reduction = "mean")`.
+#' @param num_epochs Integer. Number of training epochs (default 10).
 #'
-#' @param optim An optimizer from the torch package.
-#' Default is `optim_adam`.
+#' @param verbose Logical. If \code{TRUE} (default), prints average
+#'   loss after each epoch.
 #'
-#' @param optim_params A list of parameters to pass to the optimizer.
-#' Default is `list(lr = 0.001)`.
+#' @param preprocess_fn Optional function for custom batch
+#'   preprocessing. Receives a batch and \code{...}, must return a
+#'   list with \code{input} and \code{output} elements.
 #'
-#' @param num_epochs The number of epochs to train for. Default is 10.
+#' @param clip_grad Character string specifying gradient clipping
+#'   strategy: \code{"norm"} for max-norm clipping, \code{"value"}
+#'   for value clipping, or \code{NULL} (default) for no clipping.
 #'
-#' @param verbose A logical value indicating whether to print loss results at
-#' each epoch. Default is TRUE.
+#' @param clip_params Named list of clipping parameters. For
+#'   \code{"norm"}: \code{list(max_norm = 1.0)}. For \code{"value"}:
+#'   \code{list(clip_value = 0.5)}.
 #'
-#' @param preprocess_fn An optional function with additional, context specific
-#' steps to preprocess batches of data before training. The function must
-#' return a list containing at least `input` and `output`.
+#' @param ... Additional arguments passed to \code{preprocess_fn}.
 #'
-#' @param clip_grad A character string specifying the gradient clipping
-#' strategy. Options are `"norm"` or `"value"`. Defaults to NULL (no clipping).
+#' @returns The trained \code{scorch_model} with its \code{nn_model}
+#'   weights updated in place.
 #'
-#' @param clip_params A list of parameters for gradient clipping.
-#'  - For `"norm"`: should include `max_norm` (a numeric value).
-#'  - For `"value"`: should include `clip_value` (a numeric value).
+#' @details
+#' The training loop performs the following for each epoch:
+#'   \enumerate{
+#'     \item Iterates over batches from the attached dataloader.
+#'     \item Moves inputs and targets to the appropriate device
+#'       (CUDA if available, otherwise CPU).
+#'     \item Computes predictions via the forward pass.
+#'     \item Computes loss -- either a single loss function or the
+#'       sum of per-output losses for multi-head models.
+#'     \item Backpropagates and updates parameters.
+#'   }
 #'
-#' @param ... Additional arguments passed to the `preprocess_fn`.
-#'
-#' @return A trained scorch model.
-#'
-#' @export
+#' For multi-output models, \code{compile_scorch} must have received
+#' a named list of loss functions matching the output node names.
+#' The total loss is the sum across all outputs.
 #'
 #' @examples
+#' \dontrun{
+#' # Basic training
+#' model <- fit_scorch(model, num_epochs = 20)
 #'
-#' input  <- mtcars |> as.matrix() |> torch::torch_tensor()
+#' # With gradient clipping and custom preprocessing
+#' model <- fit_scorch(
+#'   model,
+#'   num_epochs    = 50,
+#'   preprocess_fn = my_preprocess,
+#'   clip_grad     = "norm",
+#'   clip_params   = list(max_norm = 1.0)
+#' )
+#' }
 #'
-#' output <- mtcars[, 1:2] |> as.matrix() |> torch::torch_tensor()
+#' @family model training
 #'
-#' dl <- scorch_create_dataloader(input, output, batch_size = 2)
-#'
-#' scorch_model <- dl |> initiate_scorch() |>
-#'
-#'   scorch_layer("linear", 11, 5) |>
-#'
-#'   scorch_layer("linear", 5, 2) |>
-#'
-#'   compile_scorch() |>
-#'
-#'   fit_scorch()
-#'
-#' first_batch <- head(dl)
-#'
-#' test_output <- scorch_model(first_batch$input)
+#' @export
 
-fit_scorch <- function(scorch_model,
+fit_scorch <- function(sm,
+                       num_epochs    = 10,
+                       verbose       = TRUE,
+                       preprocess_fn = NULL,
+                       clip_grad     = NULL,
+                       clip_params   = list(),
+                       ...) {
 
-  loss = nn_mse_loss, loss_params = list(reduction = "mean"),
+  #- Detect device.
 
-  optim = optim_adam, optim_params = list(lr = 0.001),
+  device <- if (torch::cuda_is_available()) {
 
-  num_epochs = 10, verbose = TRUE, preprocess_fn = NULL,
+    message("CUDA available. Training on GPU.")
 
-  clip_grad = NULL, clip_params = list(), ...) {
-
-  device <- if(cuda_is_available()) {
-
-    cat("Using available GPU.\n\n")
-
-    torch_device("cuda")
+    torch::torch_device("cuda")
 
   } else {
 
-    cat("No GPU detected. Using available CPU.\n\n")
+    message("No GPU detected. Training on CPU.")
 
-    torch_device("cpu")
+    torch::torch_device("cpu")
   }
 
-  scorch_model$nn_model <- scorch_model$nn_model$to(device = device)
+  sm$nn_model <- sm$nn_model$to(device = device)
 
-  loss_fn <- do.call(loss, loss_params)
+  optimizer <- sm$optimizer
 
-  optim_params <- append(list(
+  #- Determine if there are multiple loss functions.
 
-    params = scorch_model$nn_model$parameters), optim_params)
+  loss_fns <- sm$loss_fn
 
-  optim_fn <- do.call(optim, optim_params)
+  multi_loss <- is.list(loss_fns)
 
-  length_dl <- length(scorch_model$dl)
+  #- Set output names and batch count.
 
-  for (epoch in 1:num_epochs) {
+  outputs <- sm$outputs
 
-    total_loss = 0
+  n_out <- length(outputs)
 
-    coro::loop(for (batch in scorch_model$dl) {
+  n_batches <- length(sm$dl)
+
+  #- Training loop.
+
+  for (epoch in seq_len(num_epochs)) {
+
+    total_loss <- 0
+
+    coro::loop(for (batch in sm$dl) {
+
+      #- Prepare inputs and targets.
 
       if (!is.null(preprocess_fn)) {
 
-        preprocessed <- preprocess_fn(batch, ...)
+        p       <- preprocess_fn(batch, ...)
 
-        inputs <- lapply(preprocessed[!names(preprocessed) %in% "output"],
+        inputs  <- lapply(p$input, function(x) x$to(device = device))
 
-          function(x) x$to(device = device))
-
-        output <- preprocessed$output$to(device = device)
+        tars    <- p$output
 
       } else {
 
-        inputs <- list(input = batch$input$to(device = device))
+        inputs <- lapply(batch$input, function(x) x$to(device = device))
 
-        output <- batch$output$to(device = device)
+        tars <- batch$output
       }
 
-      optim_fn$zero_grad()
+      #- Move targets to device.
 
-      pred <- do.call(scorch_model$nn_model, c(inputs, list()))
+      if (n_out == 1) {
 
-      loss <- loss_fn(pred, output)
+        if (is.list(tars)) {
+
+          tar_list <- list(tars[[1]]$to(device = device))
+
+        } else {
+
+          tar_list <- list(tars$to(device = device))
+        }
+
+      } else {
+
+        tar_list <- lapply(tars, function(x) x$to(device = device))
+      }
+
+      #- Forward pass.
+
+      optimizer$zero_grad()
+
+      preds <- do.call(sm$nn_model, inputs)
+
+      #- Ensure preds is a list.
+
+      if (n_out == 1) {
+
+        pred_list <- list(preds)
+
+      } else {
+
+        pred_list <- preds
+      }
+
+      #- Compute loss.
+
+      if (multi_loss) {
+
+        #- Named list of losses: sum across all outputs.
+
+        loss <- torch::torch_tensor(0, dtype = torch::torch_float(),
+                                    device = device)
+
+        for (i in seq_along(outputs)) {
+
+          nm   <- outputs[i]
+          lf   <- loss_fns[[nm]]
+          pl   <- pred_list[[i]]
+          tl   <- tar_list[[i]]
+          loss <- loss + lf(pl, tl)
+        }
+
+      } else {
+
+        #- Single loss.
+
+        loss <- loss_fns(pred_list[[1]], tar_list[[1]])
+      }
 
       loss$backward()
+
+      #- Gradient clipping.
 
       if (!is.null(clip_grad)) {
 
         if (clip_grad == "norm") {
 
-          nn_utils_clip_grad_norm_(
-
-            scorch_model$nn_model$parameters, clip_params$max_norm)
+          torch::nn_utils_clip_grad_norm_(sm$nn_model$parameters,
+                                          clip_params$max_norm)
 
         } else if (clip_grad == "value") {
 
-          nn_utils_clip_grad_value_(
-
-            scorch_model$nn_model$parameters, clip_params$clip_value)
-
-        } else {
-
-          stop("Unsupported gradient clipping strategy. Use 'norm' or 'value'.")
+          torch::nn_utils_clip_grad_value_(sm$nn_model$parameters,
+                                           clip_params$clip_value)
         }
       }
 
-      optim_fn$step()
+      optimizer$step()
 
       total_loss <- total_loss + loss$item()
     })
 
-    if(verbose){
+    if (verbose) {
 
-      cat(glue::glue("Epoch {crayon::red(epoch)}, ",
+      avg_loss <- total_loss / n_batches
 
-        "Loss: {crayon::red(total_loss/length_dl)} \n\n"))
+      message(sprintf("Epoch %2d/%2d -- avg loss: %.4f",
+                      epoch, num_epochs, avg_loss))
     }
   }
 
-  return(scorch_model$nn_model)
+  sm
 }
 
 #=== END =======================================================================

--- a/R/initiate_scorch.R
+++ b/R/initiate_scorch.R
@@ -1,112 +1,116 @@
 #===============================================================================
-# FUNCTIONS TO INITIATE A SCORCH MODEL
+# FUNCTION TO INITIATE A SCORCH MODEL
 #===============================================================================
 
 #=== MAIN FUNCTION =============================================================
 
 #' Initiate a Scorch Model
 #'
-#' @param dl An input data loader, created with scorch_create_dataloader
-#'
-#' @return A scorch model object
-#'
-#' @export
-#'
-#' @examples
-#'
-#' input  <- mtcars |> as.matrix() |> torch::torch_tensor()
-#'
-#' output <- mtcars |> as.matrix() |> torch::torch_tensor()
-#'
-#' dl <- scorch_create_dataloader(input, output, batch_size = 2)
-#'
-#' dl |> initiate_scorch()
-
-initiate_scorch <- function(dl) {
-
-  l <- list(dl = dl, scorch_architecture = list())
-
-  create_scorch_model_class(l)
-}
-
-#=== HELPERS ===================================================================
-
-#--- SCORCH MODEL CLASS --------------------------------------------------------
-
-#' Create a Scorch Model Class
-#'
 #' @description
-#' #' This function creates an object of class 'scorch_model'.
+#' Creates an empty Scorch model object with a graph-based architecture.
+#' This is the first step in the scorcher pipeline: it initializes the
+#' data structure that subsequent functions (\code{\link{scorch_input}},
+#' \code{\link{scorch_layer}}, \code{\link{scorch_output}},
+#' \code{\link{compile_scorch}}) build upon.
 #'
-#' @param obj An object to be converted to a scorch model.
+#' @param dl Optional \code{torch::dataloader} to attach to the model.
+#'   If \code{NULL} (default), no dataloader is attached and one can be
+#'   added later. If provided, it must inherit from \code{"dataloader"}.
 #'
-#' @return The input object with the class attribute set to 'scorch_model'.
+#' @returns A \code{scorch_model} object (a list with class
+#'   \code{"scorch_model"}) containing the following fields:
 #'
-#' @export
+#'   \describe{
+#'     \item{\code{graph}}{A tibble with columns \code{name} (character),
+#'       \code{module} (list of \code{nn_module} objects), and \code{inputs}
+#'       (list of character vectors). Starts empty; rows are added by
+#'       \code{\link{scorch_layer}} and related functions.}
+#'     \item{\code{inputs}}{Character vector of input node names, set by
+#'       \code{\link{scorch_input}}.}
+#'     \item{\code{outputs}}{Character vector of output node names, set by
+#'       \code{\link{scorch_output}}.}
+#'     \item{\code{compiled}}{Logical. \code{FALSE} until
+#'       \code{\link{compile_scorch}} is called.}
+#'     \item{\code{nn_model}}{The compiled \code{torch::nn_module}, or
+#'       \code{NULL} before compilation.}
+#'     \item{\code{optimizer}}{The optimizer object, or \code{NULL} before
+#'       compilation.}
+#'     \item{\code{loss_fn}}{The loss function (or named list of loss
+#'       functions), or \code{NULL} before compilation.}
+#'     \item{\code{dl}}{The attached \code{torch::dataloader}, or
+#'       \code{NULL} if none was provided.}
+#'   }
+#'
+#' @details
+#' The Scorch model uses a graph-based architecture stored as a tibble.
+#' Each row represents a named node in the computation graph, holding its
+#' \code{nn_module} and a character vector of upstream node names. This
+#' allows scorcher to represent complex architectures including multi-input
+#' models, branching paths, skip connections, and multi-output heads.
+#'
+#' A typical pipeline looks like:
+#'
+#' \preformatted{
+#' model <- initiate_scorch(dl) |>
+#'   scorch_input("input") |>
+#'   scorch_layer("fc1", "linear", in_features = 10, out_features = 32) |>
+#'   scorch_layer("act1", "relu") |>
+#'   scorch_layer("fc2", "linear", in_features = 32, out_features = 1) |>
+#'   scorch_output("fc2") |>
+#'   compile_scorch()
+#' }
 #'
 #' @examples
+#' \dontrun{
+#' # With a dataloader
+#' model <- initiate_scorch(dl)
 #'
-#' scorch_model <- create_scorch_model_class(list(scorch_architecture = list()))
+#' # Without a dataloader (attach later)
+#' model <- initiate_scorch()
+#' }
 #'
-#' class(scorch_model)
-
-create_scorch_model_class <- function(obj) {
-
-  structure(obj, class = "scorch_model")
-}
-
-#--- PRINT METHOD --------------------------------------------------------------
-
-#' Print Method for Scorch Model
-#'
-#' @description
-#' This function defines the print method for objects of class 'scorch_model'.
-#'
-#' @param x An object of class 'scorch_model'.
-#'
-#' @param ... Additional arguments to be passed to the print function.
+#' @family model construction
 #'
 #' @export
-#'
-#' @examples
-#'
-#' input  <- mtcars |> as.matrix() |> torch::torch_tensor()
-#'
-#' output <- mtcars |> as.matrix() |> torch::torch_tensor()
-#'
-#' dl <- scorch_create_dataloader(input, output, batch_size = 2)
-#'
-#' scorch_model <- dl |> initiate_scorch() |>
-#'
-#'   scorch_layer("linear", 11, 5)
-#'
-#' print(scorch_model)
 
-print.scorch_model <- function(x, ...) {
+initiate_scorch <- function(dl = NULL) {
 
-  cat("This scorch model has a dataloader object with features: \n\n")
+  #- Create the base structure for a scorch_model object.
+  #- The graph tibble will hold one row per named node, with columns:
+  #-   name:    Character -- unique node identifier
+  #-   module:  List -- the nn_module for this node
+  #-   inputs:  List of character vectors -- upstream node names
 
-  print(x$dl)
+  sm <- list(
 
-  cat("\n\n and model architecture:\n\n")
+    graph     = tibble::tibble(name    = character(),
+                               module  = list(),
+                               inputs  = list()),
 
-  n_layer = length(x$scorch_architecture) / 2
+    inputs    = character(),
+    outputs   = character(),
+    compiled  = FALSE,
+    nn_model  = NULL,
+    optimizer = NULL,
+    loss_fn   = NULL,
+    dl        = NULL
+  )
 
-  if (n_layer == 0) {
+  class(sm) <- "scorch_model"
 
-    cat(" * No layers\n\n")
+  #- If a dataloader is provided, validate and attach it.
 
-  } else {
+  if (!is.null(dl)) {
 
-    for(i in 1:n_layer) {
+    if (!inherits(dl, "dataloader")) {
 
-      cat(glue::glue(" * Layer {i} is a ",
-
-        "{crayon::red(class(x$scorch_architecture[(i*2-1)][[1]])[1])}",
-
-        " layer\n\n"))
+      stop("`dl` must be a torch::dataloader.", call. = FALSE)
     }
+
+    sm$dl <- dl
   }
+
+  sm
 }
 
 #=== END =======================================================================

--- a/R/scorch_flatten.R
+++ b/R/scorch_flatten.R
@@ -14,8 +14,14 @@
 #' @param scorch_model A \code{scorch_model} object created by
 #'   \code{\link{initiate_scorch}}.
 #'
-#' @param name A single character string giving a unique name for this
-#'   node in the computation graph.
+#' @param name A unique character string identifying this node in the
+#'   model graph. Names wire the computation graph -- other nodes
+#'   reference them via their \code{inputs} argument to define
+#'   branching, fusion, and skip connections. Names are arbitrary but
+#'   appear in error messages and \code{\link{plot_scorch_model}}
+#'   output. Common prefixes: \code{"fc"} (linear), \code{"conv"}
+#'   (convolution), \code{"act"} (activation). Use number suffixes
+#'   for multiples (e.g., \code{"fc1"}, \code{"fc2"}).
 #'
 #' @param inputs Character vector of upstream node names. If \code{NULL}
 #'   (default), resolved automatically (last node or sole input).

--- a/R/scorch_flatten.R
+++ b/R/scorch_flatten.R
@@ -75,7 +75,7 @@ scorch_flatten <- function(scorch_model,
 
     } else {
 
-      inputs <- tail(scorch_model$graph$name, 1)
+      inputs <- utils::tail(scorch_model$graph$name, 1)
     }
   }
 

--- a/R/scorch_flatten.R
+++ b/R/scorch_flatten.R
@@ -1,0 +1,95 @@
+#===============================================================================
+# FUNCTION TO ADD A FLATTEN NODE TO A SCORCH MODEL
+#===============================================================================
+
+#=== MAIN FUNCTION =============================================================
+
+#' Add a Flatten Node to a Scorch Model
+#'
+#' @description
+#' Convenience wrapper that adds a \code{torch::nn_flatten} node to the
+#' Scorch model graph. Flattens contiguous dimensions of the input
+#' tensor, typically used between convolutional and linear layers.
+#'
+#' @param scorch_model A \code{scorch_model} object created by
+#'   \code{\link{initiate_scorch}}.
+#'
+#' @param name A single character string giving a unique name for this
+#'   node in the computation graph.
+#'
+#' @param inputs Character vector of upstream node names. If \code{NULL}
+#'   (default), resolved automatically (last node or sole input).
+#'
+#' @param start_dim Integer. First dimension to flatten (default 2,
+#'   preserving the batch dimension).
+#'
+#' @param end_dim Integer. Last dimension to flatten (default -1,
+#'   meaning the last dimension).
+#'
+#' @returns The updated \code{scorch_model} with a new row appended to
+#'   its \code{graph} tibble.
+#'
+#' @details
+#' This is equivalent to calling
+#' \code{scorch_layer(model, name, "flatten", start_dim = 2)} but
+#' provides a more readable API for a common operation. The default
+#' \code{start_dim = 2} preserves the batch dimension (dim 1) and
+#' flattens everything else.
+#'
+#' @examples
+#' \dontrun{
+#' # After convolutional layers, flatten before a linear layer
+#' model <- model |>
+#'   scorch_flatten("flat", inputs = "pool2") |>
+#'   scorch_layer("fc1", "linear",
+#'                in_features = 128, out_features = 64)
+#' }
+#'
+#' @family model construction
+#'
+#' @export
+
+scorch_flatten <- function(scorch_model,
+                           name,
+                           inputs = NULL,
+                           start_dim = 2,
+                           end_dim = -1) {
+
+  #- Instantiate the flatten module.
+
+  flatten_mod <- torch::nn_flatten(start_dim = start_dim, end_dim = end_dim)
+
+  #- Resolve inputs when not specified explicitly.
+
+  if (is.null(inputs)) {
+
+    if (nrow(scorch_model$graph) == 0) {
+
+      if (length(scorch_model$inputs) != 1) {
+
+        stop("Must specify 'inputs' when multiple inputs exist.",
+             call. = FALSE)
+      }
+
+      inputs <- scorch_model$inputs
+
+    } else {
+
+      inputs <- tail(scorch_model$graph$name, 1)
+    }
+  }
+
+  #- Append to graph.
+
+  scorch_model$graph <- tibble::add_row(
+
+    scorch_model$graph,
+    name    = name,
+    module  = list(flatten_mod),
+    inputs  = list(inputs)
+  )
+
+  scorch_model
+}
+
+#=== END =======================================================================

--- a/R/scorch_function.R
+++ b/R/scorch_function.R
@@ -1,52 +1,115 @@
 #===============================================================================
-# SCORCH CUSTOM FUNCTIONS
+# FUNCTION TO ADD A CUSTOM FUNCTION NODE TO A SCORCH MODEL
 #===============================================================================
 
 #=== MAIN FUNCTION =============================================================
 
-#' Add a Custom Function to a Scorch Model
+#' Add a Custom Function Node to a Scorch Model
 #'
 #' @description
-#' This function adds a custom function to the scorch model architecture.
+#' Wraps an arbitrary R function as a node in the Scorch computation
+#' graph. This is useful for operations that are not standard torch
+#' layers but are needed in the forward pass (e.g., reshaping,
+#' scaling, custom activations).
 #'
-#' @param scorch_model A scorch model object to which a custom function
-#' is to be added.
+#' @param scorch_model A \code{scorch_model} object created by
+#'   \code{\link{initiate_scorch}}.
 #'
-#' @param func A function to be added to the scorch model.
+#' @param name A single character string giving a unique name for this
+#'   node in the computation graph.
 #'
-#' @param ... Additional arguments to be passed to the custom function.
+#' @param func A function to apply during the forward pass. It will
+#'   receive the upstream tensor(s) as its first argument(s), followed
+#'   by any additional arguments captured via \code{...}.
 #'
-#' @return The updated scorch model with the custom function added to its
-#' architecture.
+#' @param inputs Character vector of upstream node names. If \code{NULL}
+#'   (default), resolved automatically (last node or sole input).
 #'
-#' @export
+#' @param ... Additional arguments passed to \code{func} at forward
+#'   time. These are captured at model-build time and baked into the
+#'   node.
+#'
+#' @returns The updated \code{scorch_model} with a new row appended to
+#'   its \code{graph} tibble.
+#'
+#' @details
+#' The function is wrapped in a lightweight \code{torch::nn_module} so
+#' it can participate in the graph alongside standard layers. Any extra
+#' arguments in \code{...} are captured at build time and passed to
+#' \code{func} on every forward call.
+#'
+#' Unlike \code{\link{scorch_layer}}, which instantiates a torch
+#' \code{nn_module} constructor, \code{scorch_function} accepts plain
+#' R functions. Use this for stateless operations that do not have
+#' learnable parameters.
 #'
 #' @examples
+#' \dontrun{
+#' # Scale a tensor by a constant
+#' model <- model |>
+#'   scorch_function("scale", function(x, factor) x * factor,
+#'                   factor = 0.1)
 #'
-#' custom_function <- function(x, factor) { x * factor }
+#' # Reshape before a linear layer
+#' model <- model |>
+#'   scorch_function("reshape", function(x) x$view(c(x$size(1), -1)))
+#' }
 #'
-#' input  <- mtcars |> as.matrix() |> torch::torch_tensor()
+#' @family model construction
 #'
-#' output <- mtcars |> as.matrix() |> torch::torch_tensor()
-#'
-#' dl <- scorch_create_dataloader(input, output, batch_size = 2)
-#'
-#' scorch_model <- dl |> initiate_scorch() |>
-#'
-#'   scorch_layer("linear", 11, 5) |>
-#'
-#'   scorch_function(custom_function, factor = 2)
+#' @export
 
-scorch_function <- function(scorch_model, func, ...) {
+scorch_function <- function(scorch_model,
+                            name,
+                            func,
+                            inputs = NULL,
+                            ...) {
 
-  func_call <- function(x) {
+  #- Capture extra arguments to bake into the forward pass.
 
-    return(func(x, ...))
+  extra_args <- list(...)
+
+  #- Wrap the function in a lightweight nn_module.
+
+  func_mod <- torch::nn_module(
+
+    initialize = function() {},
+
+    forward = function(...) {
+
+      do.call(func, c(list(...), extra_args))
+    }
+  )()
+
+  #- Resolve inputs when not specified explicitly.
+
+  if (is.null(inputs)) {
+
+    if (nrow(scorch_model$graph) == 0) {
+
+      if (length(scorch_model$inputs) != 1) {
+
+        stop("Must specify 'inputs' when multiple inputs exist.",
+             call. = FALSE)
+      }
+
+      inputs <- scorch_model$inputs
+
+    } else {
+
+      inputs <- tail(scorch_model$graph$name, 1)
+    }
   }
 
-  scorch_model$scorch_architecture <- append(scorch_model$scorch_architecture,
+  #- Append to graph.
 
-    list(func_call, type = "function"))
+  scorch_model$graph <- tibble::add_row(
+
+    scorch_model$graph,
+    name    = name,
+    module  = list(func_mod),
+    inputs  = list(inputs)
+  )
 
   scorch_model
 }

--- a/R/scorch_function.R
+++ b/R/scorch_function.R
@@ -15,8 +15,14 @@
 #' @param scorch_model A \code{scorch_model} object created by
 #'   \code{\link{initiate_scorch}}.
 #'
-#' @param name A single character string giving a unique name for this
-#'   node in the computation graph.
+#' @param name A unique character string identifying this node in the
+#'   model graph. Names wire the computation graph -- other nodes
+#'   reference them via their \code{inputs} argument to define
+#'   branching, fusion, and skip connections. Names are arbitrary but
+#'   appear in error messages and \code{\link{plot_scorch_model}}
+#'   output. Common prefixes: \code{"fc"} (linear), \code{"conv"}
+#'   (convolution), \code{"act"} (activation). Use number suffixes
+#'   for multiples (e.g., \code{"fc1"}, \code{"fc2"}).
 #'
 #' @param func A function to apply during the forward pass. It will
 #'   receive the upstream tensor(s) as its first argument(s), followed

--- a/R/scorch_function.R
+++ b/R/scorch_function.R
@@ -97,7 +97,7 @@ scorch_function <- function(scorch_model,
 
     } else {
 
-      inputs <- tail(scorch_model$graph$name, 1)
+      inputs <- utils::tail(scorch_model$graph$name, 1)
     }
   }
 

--- a/R/scorch_input.R
+++ b/R/scorch_input.R
@@ -16,9 +16,10 @@
 #' @param scorch_model A \code{scorch_model} object created by
 #'   \code{\link{initiate_scorch}}.
 #'
-#' @param name A single character string giving a unique name for this
-#'   input. Downstream layers reference this name via their \code{inputs}
-#'   argument.
+#' @param name A unique character string naming this input stream.
+#'   Other nodes reference this name via their \code{inputs} argument
+#'   to receive data from this input. For multi-input models, each
+#'   input needs a distinct name (e.g., \code{"cxr"}, \code{"ekg"}).
 #'
 #' @returns The updated \code{scorch_model} with \code{name} appended to
 #'   its \code{inputs} field.

--- a/R/scorch_input.R
+++ b/R/scorch_input.R
@@ -1,0 +1,63 @@
+#===============================================================================
+# FUNCTION TO ADD INPUT NODES TO A SCORCH MODEL
+#===============================================================================
+
+#=== MAIN FUNCTION =============================================================
+
+#' Add an Input Node to a Scorch Model
+#'
+#' @description
+#' Registers a named input node on a Scorch model. Each input node
+#' corresponds to one tensor that will be passed to the model at
+#' training or inference time. For single-input models, one call is
+#' needed; for multi-input models (e.g., late fusion), call once per
+#' input stream.
+#'
+#' @param scorch_model A \code{scorch_model} object created by
+#'   \code{\link{initiate_scorch}}.
+#'
+#' @param name A single character string giving a unique name for this
+#'   input. Downstream layers reference this name via their \code{inputs}
+#'   argument.
+#'
+#' @returns The updated \code{scorch_model} with \code{name} appended to
+#'   its \code{inputs} field.
+#'
+#' @details
+#' Input names must be unique within a model. Attempting to add a
+#' duplicate name will raise an error. The names declared here are
+#' used by \code{\link{compile_scorch}} to wire the forward pass:
+#' tensors are matched to input nodes by name (for multiple inputs)
+#' or by position (for a single input).
+#'
+#' @examples
+#' \dontrun{
+#' # Single input
+#' model <- initiate_scorch() |>
+#'   scorch_input("features")
+#'
+#' # Multi-input (e.g., two feature streams for late fusion)
+#' model <- initiate_scorch() |>
+#'   scorch_input("stream_a") |>
+#'   scorch_input("stream_b")
+#' }
+#'
+#' @family model construction
+#'
+#' @export
+
+scorch_input <- function(scorch_model, name) {
+
+  #- Validate: no duplicate input names.
+
+  if (name %in% scorch_model$inputs) {
+
+    stop("Input '", name, "' already exists.", call. = FALSE)
+  }
+
+  scorch_model$inputs <- c(scorch_model$inputs, name)
+
+  scorch_model
+}
+
+#=== END =======================================================================

--- a/R/scorch_layer.R
+++ b/R/scorch_layer.R
@@ -15,9 +15,14 @@
 #' @param scorch_model A \code{scorch_model} object created by
 #'   \code{\link{initiate_scorch}}.
 #'
-#' @param name A single character string giving a unique name for this
-#'   node in the computation graph (e.g., \code{"fc1"}, \code{"conv1"},
-#'   \code{"relu1"}).
+#' @param name A unique character string identifying this node in the
+#'   model graph. Names wire the computation graph -- other nodes
+#'   reference them via their \code{inputs} argument to define
+#'   branching, fusion, and skip connections. Names are arbitrary but
+#'   appear in error messages and \code{\link{plot_scorch_model}}
+#'   output. Common prefixes: \code{"fc"} (linear), \code{"conv"}
+#'   (convolution), \code{"act"} (activation). Use number suffixes
+#'   for multiples (e.g., \code{"fc1"}, \code{"fc2"}).
 #'
 #' @param layer_fn The layer to add. Can be specified in three ways:
 #'   \enumerate{

--- a/R/scorch_layer.R
+++ b/R/scorch_layer.R
@@ -1,175 +1,161 @@
 #===============================================================================
-# SCORCH LAYER
+# FUNCTION TO ADD A LAYER NODE TO A SCORCH MODEL
 #===============================================================================
 
 #=== MAIN FUNCTION =============================================================
 
-#' Add a Layer to a Scorch Model
+#' Add a Layer Node to a Scorch Model
 #'
 #' @description
-#' This function adds a neural network layer or a residual block to a scorch
-#' model architecture. The layer can include a single activation or a series
-#' of layers specified by a vector of layer types.
+#' Adds a named layer node to the Scorch model graph. The layer is
+#' instantiated from a torch \code{nn_*} constructor and wired to one
+#' or more upstream nodes. This is the primary function for building
+#' model architectures in scorcher.
 #'
-#' @param scorch_model A scorch model object to which the layer or block will
-#' be added.
+#' @param scorch_model A \code{scorch_model} object created by
+#'   \code{\link{initiate_scorch}}.
 #'
-#' @param layer_type A string or character vector specifying the type of
-#' layer to add (e.g., \code{c("conv2d", "gelu", "linear", "relu")}).
-#' Elements will be converted to the corresponding torch layer function
-#' (e.g., \code{nn_linear}, \code{nn_conv2d}).
+#' @param name A single character string giving a unique name for this
+#'   node in the computation graph (e.g., \code{"fc1"}, \code{"conv1"},
+#'   \code{"relu1"}).
 #'
-#' @param in_features Optional. An integer specifying the number of input
-#' features for the layer. Used for layers such as \code{nn_linear}. Default
-#' is \code{NULL}.
+#' @param layer_fn The layer to add. Can be specified in three ways:
+#'   \enumerate{
+#'     \item A string: \code{"linear"}, \code{"conv2d"}, \code{"relu"}.
+#'       The \code{nn_} prefix is added automatically if missing.
+#'     \item An unquoted name: \code{linear}, \code{conv2d}.
+#'       Resolved the same way as a string.
+#'     \item A function: \code{torch::nn_linear}, or any \code{nn_module}
+#'       constructor. Used as-is.
+#'   }
 #'
-#' @param out_features Optional. An integer specifying the number of output
-#' features for the layer. Used for layers such as \code{nn_linear}. Default
-#' is \code{NULL}.
+#' @param inputs Character vector of upstream node names that feed into
+#'   this layer. If \code{NULL} (default), inputs are resolved
+#'   automatically: the last node in the graph is used, or, if the graph
+#'   is empty, the sole input declared via \code{\link{scorch_input}}.
+#'   Must be specified explicitly when the model has multiple inputs and
+#'   the graph is empty.
 #'
-#' @param use_residual Logical value indicating whether to use a residual
-#' connection. If \code{TRUE}, the function adds a residual block of the
-#' form \code{x + f(g(x))}. Default is \code{FALSE}.
+#' @param ... Additional arguments passed to the \code{layer_fn}
+#'   constructor (e.g., \code{in_features}, \code{out_features},
+#'   \code{kernel_size}, \code{p}).
 #'
-#' @param ... Additional arguments passed to the layer constructors. These can
-#' include other required or optional parameters depending on the layer type.
+#' @returns The updated \code{scorch_model} with a new row appended to
+#'   its \code{graph} tibble.
 #'
 #' @details
-#' The \code{layer_type} argument can accept either a single string or a vector
-#' of strings. If a single string is provided, the function adds a single layer
-#' of the specified type to the model. For example, if
-#' \code{layer_type = "conv2d"}, the function will add a 2D convolutional layer.
+#' Each call appends one row to the graph tibble with columns
+#' \code{name}, \code{module} (the instantiated \code{nn_module}), and
+#' \code{inputs} (character vector of upstream node names). The graph
+#' topology is later traversed by \code{\link{compile_scorch}} to
+#' build the forward pass.
 #'
-#' If a vector of strings is provided, the function creates a sequential block
-#' consisting of multiple layers, where each element in the vector specifies a
-#' layer or activation function to include in the block. For example, if
-#' \code{layer_type = c("conv2d", "gelu", "linear", "relu")}, the function will
-#' add a block that first applies a 2D convolution, then the GELU activation,
-#' followed by a linear layer, and finally the ReLU activation.
-#'
-#' When \code{use_residual = TRUE}, the function constructs a residual
-#' connection block of the form \code{x + f(g(x))}, where \code{f} and
-#' \code{g} represent the layers and activations specified by \code{layer_type}.
-#'
-#' A residual connection is a technique where the input to a block of layers
-#' is added directly to the block's output. This creates a shortcut path, or
-#' "skip connection," that allows the original input to bypass one or more
-#' layers. Residual connections are beneficial for training deep networks
-#' because they help mitigate the vanishing gradient problem by allowing
-#' gradients to flow more easily through the network.
-#'
-#' @return Returns the updated scorch model with the new layer or block
-#' added to its architecture.
+#' For residual / skip connections, use \code{\link{scorch_add_skip}}
+#' instead of the old \code{use_residual} argument.
 #'
 #' @examples
+#' \dontrun{
+#' # String (most common)
+#' model <- model |>
+#'   scorch_layer("fc1", "linear", in_features = 10, out_features = 32)
 #'
-#' input  <- mtcars |> as.matrix() |> torch::torch_tensor()
+#' # Unquoted symbol
+#' model <- model |>
+#'   scorch_layer("act1", relu)
 #'
-#' output <- mtcars |> as.matrix() |> torch::torch_tensor()
+#' # Direct nn_module constructor
+#' model <- model |>
+#'   scorch_layer("fc2", torch::nn_linear,
+#'                in_features = 32, out_features = 1)
 #'
-#' dl <- scorch_create_dataloader(input, output, batch_size = 2)
+#' # Explicit input wiring (for multi-input models)
+#' model <- model |>
+#'   scorch_layer("branch_a", "linear", inputs = "stream_a",
+#'                in_features = 10, out_features = 16)
+#' }
 #'
-#' scorch_model <- dl |> initiate_scorch() |>
-#'
-#'   scorch_layer(layer_type = "linear", 16, 32)
-#'
-#' scorch_model <- scorch_model |>
-#'
-#'   scorch_layer(layer_type = c("linear", "relu"),
-#'
-#'    in_features = 16, out_features = 32, use_residual = TRUE)
+#' @family model construction
 #'
 #' @export
 
-scorch_layer <- function(scorch_model, layer_type,
+scorch_layer <- function(scorch_model,
+                         name,
+                         layer_fn,
+                         inputs = NULL,
+                         ...) {
 
-  in_features = NULL, out_features = NULL, use_residual = FALSE, ...) {
+  #- Capture the raw call to distinguish strings, symbols, and functions.
 
-  # Convert layer_type to lowercase to ensure consistency
+  mc <- match.call()
 
-  layer_type <- tolower(layer_type)
+  fn_expr <- mc$layer_fn
 
-  # Check if all layer types are valid
+  if (is.symbol(fn_expr) || is.character(layer_fn)) {
 
-  valid_layers <- sapply(layer_type, function(layer) {
+    #- Either an unquoted name (symbol) or a string.
 
-    function_name <- paste0("nn_", layer)
+    fn_name <- if (is.symbol(fn_expr)) as.character(fn_expr) else layer_fn
 
-    exists(function_name, envir = asNamespace("torch"))
-  })
+    #- Auto-prepend nn_ if not already present.
 
-  if (!all(valid_layers)) {
+    if (!grepl("^nn_", fn_name)) fn_name <- paste0("nn_", fn_name)
 
-    invalid_layers <- layer_type[!valid_layers]
+    #- Check that the function exists in torch.
 
-    stop(paste("Invalid layer types detected:",
+    if (!exists(fn_name, envir = asNamespace("torch"), mode = "function")) {
 
-      paste(invalid_layers, collapse = ", ")))
-  }
-
-  # Create layers
-
-  layers <- lapply(layer_type, function(layer) {
-
-    function_name <- paste0("nn_", layer)
-
-    nn_function <- get(function_name, envir = asNamespace("torch"))
-
-    # Collect optional arguments
-
-    args_list <- list(...)
-
-    if ("in_features" %in% names(formals(nn_function))) {
-
-      args_list$in_features <- in_features
+      stop("No torch layer called '", fn_name, "'.", call. = FALSE)
     }
 
-    if ("out_features" %in% names(formals(nn_function))) {
+    layer_fn <- get(fn_name, envir = asNamespace("torch"))
 
-      args_list$out_features <- out_features
-    }
+  } else if (is.function(layer_fn)) {
 
-    do.call(nn_function, args_list)
-  })
-
-  if (use_residual) {
-
-    # If residual connection is used, wrap the layers in a residual block
-
-    residual_block <- nn_module(
-
-      initialize = function() {
-
-        self$block <- nn_sequential(!!!layers)
-      },
-
-      forward = function(x) {
-
-        x_residual <- self$block(x)
-
-        x + x_residual
-      }
-    )
-
-    res_layer <- residual_block()
-
-    class(res_layer) <- c("residual_block", class(res_layer))
-
-    scorch_model$scorch_architecture <- append(
-
-      scorch_model$scorch_architecture, list(res_layer, type = "layer"))
+    #- User passed a constructor directly -- keep it.
+    NULL
 
   } else {
 
-    # Add the sequential block of layers to the model
+    stop("`layer_fn` must be a torch layer name or function.", call. = FALSE)
+  }
 
-    for (i in seq_along(layers)) {
+  #- Resolve inputs when not specified explicitly.
 
-      scorch_model$scorch_architecture <- append(
+  if (is.null(inputs)) {
 
-        scorch_model$scorch_architecture, list(layers[[i]], type = "layer"))
+    if (nrow(scorch_model$graph) == 0) {
+
+      #- Graph is empty: must have exactly one declared input.
+
+      if (length(scorch_model$inputs) != 1) {
+
+        stop("Must specify 'inputs' when multiple inputs exist.",
+             call. = FALSE)
+      }
+
+      inputs <- scorch_model$inputs
+
+    } else {
+
+      #- Default to the last node in the graph.
+
+      inputs <- tail(scorch_model$graph$name, 1)
     }
   }
+
+  #- Instantiate the module.
+
+  module <- do.call(layer_fn, list(...))
+
+  #- Append to graph.
+
+  scorch_model$graph <- tibble::add_row(
+
+    scorch_model$graph,
+    name    = name,
+    module  = list(module),
+    inputs  = list(inputs)
+  )
 
   scorch_model
 }

--- a/R/scorch_layer.R
+++ b/R/scorch_layer.R
@@ -139,7 +139,7 @@ scorch_layer <- function(scorch_model,
 
       #- Default to the last node in the graph.
 
-      inputs <- tail(scorch_model$graph$name, 1)
+      inputs <- utils::tail(scorch_model$graph$name, 1)
     }
   }
 

--- a/R/scorch_output.R
+++ b/R/scorch_output.R
@@ -15,9 +15,10 @@
 #' @param scorch_model A \code{scorch_model} object created by
 #'   \code{\link{initiate_scorch}}.
 #'
-#' @param outputs A character vector of one or more node names from
-#'   the model graph. Each name must correspond to a node added by
-#'   \code{\link{scorch_layer}} or a similar function.
+#' @param outputs A character vector of node names to designate as
+#'   model outputs. These names must match existing nodes in the
+#'   graph. For single-output models, pass one name. For multi-output
+#'   models, pass multiple (e.g., \code{c("cls_head", "reg_head")}).
 #'
 #' @returns The updated \code{scorch_model} with its \code{outputs}
 #'   field set to \code{outputs}.

--- a/R/scorch_output.R
+++ b/R/scorch_output.R
@@ -1,0 +1,62 @@
+#===============================================================================
+# FUNCTION TO MARK OUTPUT NODES ON A SCORCH MODEL
+#===============================================================================
+
+#=== MAIN FUNCTION =============================================================
+
+#' Mark Output Nodes on a Scorch Model
+#'
+#' @description
+#' Declares which graph nodes should be treated as model outputs.
+#' For single-output models, pass a single node name; for multi-output
+#' models (e.g., multi-head architectures), pass a character vector
+#' of node names.
+#'
+#' @param scorch_model A \code{scorch_model} object created by
+#'   \code{\link{initiate_scorch}}.
+#'
+#' @param outputs A character vector of one or more node names from
+#'   the model graph. Each name must correspond to a node added by
+#'   \code{\link{scorch_layer}} or a similar function.
+#'
+#' @returns The updated \code{scorch_model} with its \code{outputs}
+#'   field set to \code{outputs}.
+#'
+#' @details
+#' The output nodes determine what the compiled model returns from
+#' its forward pass. For a single output, the model returns one tensor.
+#' For multiple outputs, it returns a list of tensors -- one per output
+#' node, in the order specified here. When using multiple outputs,
+#' \code{\link{compile_scorch}} expects a named list of loss functions
+#' matching these output names.
+#'
+#' @examples
+#' \dontrun{
+#' # Single output
+#' model <- model |>
+#'   scorch_output("fc_out")
+#'
+#' # Multi-output (e.g., regression head + classification head)
+#' model <- model |>
+#'   scorch_output(c("reg_head", "cls_head"))
+#' }
+#'
+#' @family model construction
+#'
+#' @export
+
+scorch_output <- function(scorch_model, outputs) {
+
+  #- Validate: outputs must be a character vector.
+
+  if (!is.character(outputs)) {
+
+    stop("`outputs` must be a character vector of node names.", call. = FALSE)
+  }
+
+  scorch_model$outputs <- outputs
+
+  scorch_model
+}
+
+#=== END =======================================================================

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,7 +1,0 @@
-scorch_flatten = function(...){
-  l = list(...)
-  f = function(x){
-    torch_flatten(x,l)
-  }
-  return(f)
-}


### PR DESCRIPTION
Based on Steve's modular branch design, this is a core architecture rewrite, transitioning Scorch from a flat sequential list to a graph-based computational model. 
Models are now represented as a tibble with columns name, module, and inputs, enabling multi-input, multi-output and branching architectures like late fusion, residual connections, etc.

**Files rewritten:**

1. `initiate_scorch()` -- creates graph-based scorch_model object; dataloader now optional
2. `scorch_layer()` -- adds named nodes to graph; accepts string, symbol, or function for layer type
3. `scorch_function()` -- wraps arbitrary R functions as graph nodes via lightweight `nn_module`
4. `compile_scorch()`-- traverses graph topology to build nn_module; takes `loss_fn`, `optimizer_fn`, `optimizer_params` (replaces old init_fn/forward_fn)
5. `fit_scorch()` -- trains using pre-attached optimizer/loss from compile; supports multi-output with named loss lists
6. `create_dataloader()` -- accepts tensors, arrays, or named lists; auto-converts dtypes for classification/regression

**New files:**

7. `scorch_input()` -- declares named input nodes
8. `scorch_output()` -- declares named output nodes
9. `scorch_flatten()` -- convenience wrapper for `nn_flatten` (replaces old function in utils.R)

**Removed:** utils.R (empty after scorch_flatten extracted), create_scorch_nn_module_class, print.scorch_nn_module, create_scorch_dataloader_class, calc_dim, head.scorch_dataloader, print.scorch_dataloader

DESCRIPTION: Adds `purrr`, `tibble` to Imports. Removes unused `glue`, `stringr`. Adds `@import torch` to `compile_scorch` for namespace availability.