### PR TITLE
Add graph node helpers, print/plot methods and Roxygen docs 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,18 +12,22 @@ RoxygenNote: 7.3.2
 Imports: 
     coro,
     crayon,
+    dplyr,
     glue,
+    purrr,
     stringr,
+    tibble,
     torch,
     utils
 Config/Needs/website: rmarkdown
 Suggests: 
-    knitr,
-    rmarkdown,
-    ggimage,
-    palmerpenguins,
     datasauRus,
-    tidyverse,
+    DiagrammeR,
+    ggimage,
+    knitr,
+    palmerpenguins,
+    rmarkdown,
     tensorflow,
-    tfdatasets
+    tfdatasets,
+    tidyverse
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,9 +13,7 @@ Imports:
     coro,
     crayon,
     dplyr,
-    glue,
     purrr,
-    stringr,
     tibble,
     torch,
     utils

--- a/R/plot_scorch_model.R
+++ b/R/plot_scorch_model.R
@@ -1,0 +1,125 @@
+#===============================================================================
+# PLOT METHOD FOR SCORCH MODEL
+#===============================================================================
+
+#=== MAIN FUNCTION =============================================================
+
+#' Plot a Scorch Model Architecture
+#'
+#' @description
+#' Renders the Scorch model computation graph as a directed graph
+#' using Graphviz via the DiagrammeR package. Input nodes are shown
+#' as ovals, output nodes as double circles, and all other nodes as
+#' boxes.
+#'
+#' @param scorch_model A compiled \code{scorch_model} object.
+#'
+#' @param detailed Logical. If \code{TRUE}, show weight dimensions
+#'   next to each node label. Default \code{FALSE}.
+#'
+#' @returns A \code{DiagrammeR} htmlwidget object (rendered
+#'   automatically in interactive sessions).
+#'
+#' @details
+#' Requires the DiagrammeR package to be installed. If it is not
+#' available, the function raises an informative error.
+#'
+#' Nodes are laid out left-to-right (\code{rankdir=LR}). Edges
+#' follow the \code{inputs} declared in the graph tibble.
+#'
+#' @examples
+#' \dontrun{
+#' plot_scorch_model(model)
+#' plot_scorch_model(model, detailed = TRUE)
+#' }
+#'
+#' @family model construction
+#'
+#' @export
+
+plot_scorch_model <- function(scorch_model,
+                              detailed = FALSE) {
+
+  if (!requireNamespace("DiagrammeR", quietly = TRUE)) {
+
+    stop("Package 'DiagrammeR' is required for plot_scorch_model(). ",
+         "Install it with install.packages('DiagrammeR').",
+         call. = FALSE)
+  }
+
+  nodes   <- scorch_model$graph$name
+  inputs  <- scorch_model$inputs
+  outputs <- scorch_model$outputs
+
+  #- Node definitions.
+
+  node_defs <- c(
+
+    #- Input nodes (ovals).
+
+    vapply(inputs, function(nm) {
+
+      sprintf('%s [shape=oval, style=filled, fillcolor="lightblue", label="%s"]',
+              nm, nm)
+    }, ""),
+
+    #- Internal and output nodes.
+
+    vapply(nodes, function(nm) {
+
+      mod  <- scorch_model$nn_model[[nm]]
+
+      type <- class(mod)[1]
+
+      dims_lbl <- ""
+
+      if (detailed &&
+          !is.null(mod$weight) &&
+          inherits(mod$weight, "torch_tensor")) {
+
+        dims_lbl <- paste0("\n(",
+                           paste(mod$weight$size(), collapse = "x"),
+                           ")")
+      }
+
+      shape <- if (nm %in% outputs) "doublecircle" else "box"
+
+      label <- if (detailed) {
+
+        paste0(nm, "\n", type, dims_lbl)
+
+      } else {
+
+        paste0(nm, "\n", type)
+      }
+
+      sprintf('%s [shape=%s, label="%s"]', nm, shape, label)
+
+    }, "")
+  )
+
+  #- Edge definitions.
+
+  edge_defs <- unlist(lapply(seq_len(nrow(scorch_model$graph)), function(i) {
+
+    to    <- scorch_model$graph$name[i]
+
+    froms <- scorch_model$graph$inputs[[i]]
+
+    vapply(froms, function(fr) sprintf("%s -> %s", fr, to), "")
+  }))
+
+  #- Assemble DOT string and render.
+
+  dot <- paste(
+    "digraph G {",
+    "rankdir=LR;",
+    paste(node_defs, collapse = ";\n"), ";",
+    paste(edge_defs, collapse = ";\n"), ";",
+    "}"
+  )
+
+  DiagrammeR::grViz(dot)
+}
+
+#=== END =======================================================================

--- a/R/print.scorch_model.R
+++ b/R/print.scorch_model.R
@@ -2,6 +2,8 @@
 # PRINT METHOD FOR SCORCH MODEL
 #===============================================================================
 
+
+utils::globalVariables(c("name", "inputs", "module_type", "dims"))
 #=== MAIN FUNCTION =============================================================
 
 #' Print a Scorch Model

--- a/R/print.scorch_model.R
+++ b/R/print.scorch_model.R
@@ -1,0 +1,117 @@
+#===============================================================================
+# PRINT METHOD FOR SCORCH MODEL
+#===============================================================================
+
+#=== MAIN FUNCTION =============================================================
+
+#' Print a Scorch Model
+#'
+#' @description
+#' Displays a summary of a \code{scorch_model} object, including its
+#' input and output nodes and a table of the graph architecture. If
+#' \code{detailed = TRUE} and the model has been compiled, weight
+#' dimensions are also shown.
+#'
+#' @param x A \code{scorch_model} object.
+#'
+#' @param detailed Logical. If \code{TRUE}, show weight dimensions for
+#'   each layer (requires the model to be compiled). Default
+#'   \code{FALSE}.
+#'
+#' @param ... Additional arguments (currently unused).
+#'
+#' @returns \code{x}, invisibly.
+#'
+#' @examples
+#' \dontrun{
+#' print(model)
+#' print(model, detailed = TRUE)
+#' }
+#'
+#' @family model construction
+#'
+#' @export
+
+print.scorch_model <- function(x,
+                               detailed = FALSE,
+                               ...) {
+
+  cat("<< Scorch Model >>\n")
+
+  cat(" Inputs : ", paste(x$inputs, collapse = ", "), "\n")
+
+  cat(" Outputs: ", paste(x$outputs, collapse = ", "), "\n")
+
+  cat(" Compiled:", x$compiled, "\n\n")
+
+  #- If graph is empty, nothing more to show.
+
+  if (nrow(x$graph) == 0) {
+
+    cat(" (no layers added yet)\n")
+
+    return(invisible(x))
+  }
+
+  #- If compiled, show module types from nn_model.
+
+  if (x$compiled) {
+
+    df <- x$graph |>
+
+      dplyr::mutate(
+
+        module_type = purrr::map_chr(name, ~ class(x$nn_model[[.x]])[1]),
+        inputs      = purrr::map_chr(inputs, ~ paste(.x, collapse = ", "))
+      )
+
+    if (detailed) {
+
+      df <- df |>
+
+        dplyr::mutate(
+
+          dims = purrr::map_chr(name, function(nm) {
+
+            mod <- x$nn_model[[nm]]
+
+            if (!is.null(mod$weight) &&
+                inherits(mod$weight, "torch_tensor")) {
+
+              paste(mod$weight$size(), collapse = "x")
+
+            } else {
+
+              ""
+            }
+          })
+        ) |>
+
+        dplyr::select(name, inputs, module_type, dims)
+
+    } else {
+
+      df <- df |>
+
+        dplyr::select(name, inputs, module_type)
+    }
+
+  } else {
+
+    #- Not yet compiled: show graph structure only.
+
+    df <- x$graph |>
+
+      dplyr::mutate(
+        inputs = purrr::map_chr(inputs, ~ paste(.x, collapse = ", "))
+      ) |>
+
+      dplyr::select(name, inputs)
+  }
+
+  print(df)
+
+  invisible(x)
+}
+
+#=== END =======================================================================

--- a/R/scorch_add_skip.R
+++ b/R/scorch_add_skip.R
@@ -14,8 +14,14 @@
 #' @param scorch_model A \code{scorch_model} object created by
 #'   \code{\link{initiate_scorch}}.
 #'
-#' @param name A single character string giving a unique name for this
-#'   skip node in the computation graph.
+#' @param name A unique character string identifying this node in the
+#'   model graph. Names wire the computation graph -- other nodes
+#'   reference them via their \code{inputs} argument to define
+#'   branching, fusion, and skip connections. Names are arbitrary but
+#'   appear in error messages and \code{\link{plot_scorch_model}}
+#'   output. Common prefixes: \code{"fc"} (linear), \code{"conv"}
+#'   (convolution), \code{"act"} (activation). Use number suffixes
+#'   for multiples (e.g., \code{"fc1"}, \code{"fc2"}).
 #'
 #' @param inputs A length-2 character vector: \code{c("main_path",
 #'   "skip_path")}. Both upstream nodes must produce tensors of the

--- a/R/scorch_add_skip.R
+++ b/R/scorch_add_skip.R
@@ -1,0 +1,81 @@
+#===============================================================================
+# FUNCTION TO ADD A SKIP CONNECTION NODE TO A SCORCH MODEL
+#===============================================================================
+
+#=== MAIN FUNCTION =============================================================
+
+#' Add a Skip Connection Node to a Scorch Model
+#'
+#' @description
+#' Creates a node that performs element-wise addition of two upstream
+#' tensors. Used to implement residual / skip connections where the
+#' output is \code{x + skip}.
+#'
+#' @param scorch_model A \code{scorch_model} object created by
+#'   \code{\link{initiate_scorch}}.
+#'
+#' @param name A single character string giving a unique name for this
+#'   skip node in the computation graph.
+#'
+#' @param inputs A length-2 character vector: \code{c("main_path",
+#'   "skip_path")}. Both upstream nodes must produce tensors of the
+#'   same shape.
+#'
+#' @returns The updated \code{scorch_model} with a new row appended to
+#'   its \code{graph} tibble.
+#'
+#' @details
+#' The node is implemented as a lightweight \code{torch::nn_module}
+#' that sums its two inputs. It has no learnable parameters. This
+#' replaces the old \code{use_residual} argument in
+#' \code{\link{scorch_layer}}.
+#'
+#' @examples
+#' \dontrun{
+#' # Residual connection around a linear + relu block
+#' model <- model |>
+#'   scorch_layer("fc1", "linear", inputs = "x",
+#'                in_features = 32, out_features = 32) |>
+#'   scorch_layer("act1", "relu") |>
+#'   scorch_add_skip("res1", inputs = c("act1", "x"))
+#' }
+#'
+#' @family model construction
+#'
+#' @export
+
+scorch_add_skip <- function(scorch_model,
+                            name,
+                            inputs) {
+
+  if (length(inputs) != 2) {
+
+    stop("`inputs` must be length 2.", call. = FALSE)
+  }
+
+  #- Build a lightweight module that sums its two inputs.
+
+  skip_mod <- torch::nn_module(
+
+    initialize = function() {},
+
+    forward = function(x, skip) {
+
+      x + skip
+    }
+  )()
+
+  #- Append to graph.
+
+  scorch_model$graph <- tibble::add_row(
+
+    scorch_model$graph,
+    name   = name,
+    module = list(skip_mod),
+    inputs = list(inputs)
+  )
+
+  scorch_model
+}
+
+#=== END =======================================================================

--- a/R/scorch_attention.R
+++ b/R/scorch_attention.R
@@ -14,8 +14,14 @@
 #' @param scorch_model A \code{scorch_model} object created by
 #'   \code{\link{initiate_scorch}}.
 #'
-#' @param name A single character string giving a unique name for this
-#'   node in the computation graph.
+#' @param name A unique character string identifying this node in the
+#'   model graph. Names wire the computation graph -- other nodes
+#'   reference them via their \code{inputs} argument to define
+#'   branching, fusion, and skip connections. Names are arbitrary but
+#'   appear in error messages and \code{\link{plot_scorch_model}}
+#'   output. Common prefixes: \code{"fc"} (linear), \code{"conv"}
+#'   (convolution), \code{"act"} (activation). Use number suffixes
+#'   for multiples (e.g., \code{"fc1"}, \code{"fc2"}).
 #'
 #' @param inputs Character vector of three upstream node names:
 #'   \code{c("query", "key", "value")}.

--- a/R/scorch_attention.R
+++ b/R/scorch_attention.R
@@ -1,0 +1,71 @@
+#===============================================================================
+# FUNCTION TO ADD A MULTI-HEAD ATTENTION NODE TO A SCORCH MODEL
+#===============================================================================
+
+#=== MAIN FUNCTION =============================================================
+
+#' Add a Multi-Head Attention Node to a Scorch Model
+#'
+#' @description
+#' Adds a \code{torch::nn_multihead_attention} node to the Scorch
+#' model graph. The node expects three upstream inputs representing
+#' query, key, and value tensors.
+#'
+#' @param scorch_model A \code{scorch_model} object created by
+#'   \code{\link{initiate_scorch}}.
+#'
+#' @param name A single character string giving a unique name for this
+#'   node in the computation graph.
+#'
+#' @param inputs Character vector of three upstream node names:
+#'   \code{c("query", "key", "value")}.
+#'
+#' @param embed_dim Integer. Total embedding dimension.
+#'
+#' @param num_heads Integer. Number of attention heads.
+#'
+#' @param ... Additional arguments passed to
+#'   \code{torch::nn_multihead_attention()} (e.g., \code{dropout}).
+#'
+#' @returns The updated \code{scorch_model} with a new row appended to
+#'   its \code{graph} tibble.
+#'
+#' @details
+#' The \code{embed_dim} must be divisible by \code{num_heads}. The
+#' three inputs correspond to the query, key, and value tensors
+#' passed to the attention mechanism.
+#'
+#' @examples
+#' \dontrun{
+#' model <- model |>
+#'   scorch_attention("attn1",
+#'                    inputs    = c("query", "key", "value"),
+#'                    embed_dim = 64,
+#'                    num_heads = 4)
+#' }
+#'
+#' @family model construction
+#'
+#' @export
+
+scorch_attention <- function(scorch_model,
+                             name,
+                             inputs,
+                             embed_dim,
+                             num_heads,
+                             ...) {
+
+  attn_mod <- torch::nn_multihead_attention(embed_dim, num_heads, ...)
+
+  scorch_model$graph <- tibble::add_row(
+
+    scorch_model$graph,
+    name   = name,
+    module = list(attn_mod),
+    inputs = list(inputs)
+  )
+
+  scorch_model
+}
+
+#=== END =======================================================================

--- a/R/scorch_batchnorm.R
+++ b/R/scorch_batchnorm.R
@@ -1,0 +1,90 @@
+#===============================================================================
+# FUNCTION TO ADD A BATCH NORMALIZATION NODE TO A SCORCH MODEL
+#===============================================================================
+
+#=== MAIN FUNCTION =============================================================
+
+#' Add a Batch Normalization Node to a Scorch Model
+#'
+#' @description
+#' Convenience wrapper that adds a \code{torch::nn_batch_norm1d} node
+#' to the Scorch model graph.
+#'
+#' @param scorch_model A \code{scorch_model} object created by
+#'   \code{\link{initiate_scorch}}.
+#'
+#' @param name A single character string giving a unique name for this
+#'   node in the computation graph.
+#'
+#' @param inputs Character vector of upstream node names. If \code{NULL}
+#'   (default), resolved automatically (last node or sole input).
+#'
+#' @param num_features Integer. Number of features (the C dimension in
+#'   BatchNorm1d).
+#'
+#' @param ... Additional arguments passed to
+#'   \code{torch::nn_batch_norm1d()} (e.g., \code{momentum},
+#'   \code{eps}).
+#'
+#' @returns The updated \code{scorch_model} with a new row appended to
+#'   its \code{graph} tibble.
+#'
+#' @details
+#' This is equivalent to calling
+#' \code{scorch_layer(model, name, "batch_norm1d", inputs, num_features = n)}
+#' but provides a more readable API for a common operation.
+#'
+#' @examples
+#' \dontrun{
+#' model <- model |>
+#'   scorch_layer("fc1", "linear", in_features = 10, out_features = 32) |>
+#'   scorch_batchnorm("bn1", num_features = 32) |>
+#'   scorch_layer("act1", "relu")
+#' }
+#'
+#' @family model construction
+#'
+#' @export
+
+scorch_batchnorm <- function(scorch_model,
+                             name,
+                             inputs = NULL,
+                             num_features,
+                             ...) {
+
+  bn_mod <- torch::nn_batch_norm1d(num_features = num_features, ...)
+
+  #- Resolve inputs when not specified explicitly.
+
+  if (is.null(inputs)) {
+
+    if (nrow(scorch_model$graph) == 0) {
+
+      if (length(scorch_model$inputs) != 1) {
+
+        stop("Must specify 'inputs' when multiple inputs exist.",
+             call. = FALSE)
+      }
+
+      inputs <- scorch_model$inputs
+
+    } else {
+
+      inputs <- tail(scorch_model$graph$name, 1)
+    }
+  }
+
+  #- Append to graph.
+
+  scorch_model$graph <- tibble::add_row(
+
+    scorch_model$graph,
+    name   = name,
+    module = list(bn_mod),
+    inputs = list(inputs)
+  )
+
+  scorch_model
+}
+
+#=== END =======================================================================

--- a/R/scorch_batchnorm.R
+++ b/R/scorch_batchnorm.R
@@ -13,8 +13,14 @@
 #' @param scorch_model A \code{scorch_model} object created by
 #'   \code{\link{initiate_scorch}}.
 #'
-#' @param name A single character string giving a unique name for this
-#'   node in the computation graph.
+#' @param name A unique character string identifying this node in the
+#'   model graph. Names wire the computation graph -- other nodes
+#'   reference them via their \code{inputs} argument to define
+#'   branching, fusion, and skip connections. Names are arbitrary but
+#'   appear in error messages and \code{\link{plot_scorch_model}}
+#'   output. Common prefixes: \code{"fc"} (linear), \code{"conv"}
+#'   (convolution), \code{"act"} (activation). Use number suffixes
+#'   for multiples (e.g., \code{"fc1"}, \code{"fc2"}).
 #'
 #' @param inputs Character vector of upstream node names. If \code{NULL}
 #'   (default), resolved automatically (last node or sole input).

--- a/R/scorch_batchnorm.R
+++ b/R/scorch_batchnorm.R
@@ -70,7 +70,7 @@ scorch_batchnorm <- function(scorch_model,
 
     } else {
 
-      inputs <- tail(scorch_model$graph$name, 1)
+      inputs <- utils::tail(scorch_model$graph$name, 1)
     }
   }
 

--- a/R/scorch_concat.R
+++ b/R/scorch_concat.R
@@ -1,0 +1,76 @@
+#===============================================================================
+# FUNCTION TO ADD A CONCATENATION NODE TO A SCORCH MODEL
+#===============================================================================
+
+#=== MAIN FUNCTION =============================================================
+
+#' Add a Concatenation Node to a Scorch Model
+#'
+#' @description
+#' Concatenates the outputs of two or more upstream nodes along a
+#' specified dimension. Commonly used to merge parallel branches
+#' in multi-input or late-fusion architectures.
+#'
+#' @param scorch_model A \code{scorch_model} object created by
+#'   \code{\link{initiate_scorch}}.
+#'
+#' @param name A single character string giving a unique name for this
+#'   node in the computation graph.
+#'
+#' @param inputs Character vector of two or more upstream node names
+#'   whose outputs will be concatenated.
+#'
+#' @param dim Integer. Dimension along which to concatenate (default 1,
+#'   which is typically the feature dimension after the batch dimension).
+#'   Use \code{dim = 2} when concatenating feature vectors.
+#'
+#' @returns The updated \code{scorch_model} with a new row appended to
+#'   its \code{graph} tibble.
+#'
+#' @details
+#' The node is implemented as a lightweight \code{torch::nn_module}
+#' that calls \code{torch::torch_cat()} on its inputs. It has no
+#' learnable parameters.
+#'
+#' @examples
+#' \dontrun{
+#' # Merge two branches for late fusion
+#' model <- model |>
+#'   scorch_concat("merged", inputs = c("branch_a", "branch_b"), dim = 2)
+#' }
+#'
+#' @family model construction
+#'
+#' @export
+
+scorch_concat <- function(scorch_model,
+                          name,
+                          inputs,
+                          dim = 1) {
+
+  #- Build a lightweight module that concatenates its inputs.
+
+  concat_mod <- torch::nn_module(
+
+    initialize = function() {},
+
+    forward = function(...) {
+
+      torch::torch_cat(list(...), dim = dim)
+    }
+  )()
+
+  #- Append to graph.
+
+  scorch_model$graph <- tibble::add_row(
+
+    scorch_model$graph,
+    name   = name,
+    module = list(concat_mod),
+    inputs = list(inputs)
+  )
+
+  scorch_model
+}
+
+#=== END =======================================================================

--- a/R/scorch_concat.R
+++ b/R/scorch_concat.R
@@ -14,8 +14,14 @@
 #' @param scorch_model A \code{scorch_model} object created by
 #'   \code{\link{initiate_scorch}}.
 #'
-#' @param name A single character string giving a unique name for this
-#'   node in the computation graph.
+#' @param name A unique character string identifying this node in the
+#'   model graph. Names wire the computation graph -- other nodes
+#'   reference them via their \code{inputs} argument to define
+#'   branching, fusion, and skip connections. Names are arbitrary but
+#'   appear in error messages and \code{\link{plot_scorch_model}}
+#'   output. Common prefixes: \code{"fc"} (linear), \code{"conv"}
+#'   (convolution), \code{"act"} (activation). Use number suffixes
+#'   for multiples (e.g., \code{"fc1"}, \code{"fc2"}).
 #'
 #' @param inputs Character vector of two or more upstream node names
 #'   whose outputs will be concatenated.

--- a/R/scorch_diffusion.R
+++ b/R/scorch_diffusion.R
@@ -25,10 +25,12 @@
 #' @param beta_schedule The schedule type for beta values, either "linear" or
 #' "quadratic". Default is "linear".
 #'
-#' @return A `NoiseScheduler` object with methods for managing the diffusion
+#' @returns A `NoiseScheduler` object with methods for managing the diffusion
 #' process.
 #'
 #' @references <https://github.com/tanelp/tiny-diffusion>
+#'
+#' @family diffusion
 #'
 #' @export
 
@@ -182,7 +184,9 @@ NoiseScheduler <- nn_module(
 #'
 #' @param scale The scaling factor for input embeddings. Default is 1.0.
 #'
-#' @return None. The function modifies the `model` in place.
+#' @returns None. The function modifies the `model` in place.
+#'
+#' @family diffusion
 #'
 #' @export
 
@@ -214,7 +218,9 @@ scorch_2d_diffusion_init <- function(model, emb_size = 128,
 #'
 #' @param timesteps The current timesteps in the diffusion process.
 #'
-#' @return The processed input tensor after embedding and concatenation.
+#' @returns The processed input tensor after embedding and concatenation.
+#'
+#' @family diffusion
 #'
 #' @export
 
@@ -245,8 +251,10 @@ scorch_2d_diffusion_forward <- function(model, input, timesteps) {
 #'
 #' @param ... Additional arguments for customization.
 #'
-#' @return A list containing the noisy inputs, the noise added, and the
+#' @returns A list containing the noisy inputs, the noise added, and the
 #' timesteps used.
+#'
+#' @family diffusion
 #'
 #' @export
 

--- a/R/scorch_dropout.R
+++ b/R/scorch_dropout.R
@@ -1,0 +1,87 @@
+#===============================================================================
+# FUNCTION TO ADD A DROPOUT NODE TO A SCORCH MODEL
+#===============================================================================
+
+#=== MAIN FUNCTION =============================================================
+
+#' Add a Dropout Node to a Scorch Model
+#'
+#' @description
+#' Convenience wrapper that adds a \code{torch::nn_dropout} node to
+#' the Scorch model graph.
+#'
+#' @param scorch_model A \code{scorch_model} object created by
+#'   \code{\link{initiate_scorch}}.
+#'
+#' @param name A single character string giving a unique name for this
+#'   node in the computation graph.
+#'
+#' @param inputs Character vector of upstream node names. If \code{NULL}
+#'   (default), resolved automatically (last node or sole input).
+#'
+#' @param p Numeric. Dropout probability (default 0.5).
+#'
+#' @param ... Additional arguments passed to \code{torch::nn_dropout()}.
+#'
+#' @returns The updated \code{scorch_model} with a new row appended to
+#'   its \code{graph} tibble.
+#'
+#' @details
+#' This is equivalent to calling
+#' \code{scorch_layer(model, name, "dropout", inputs, p = 0.5)} but
+#' provides a more readable API for a common operation.
+#'
+#' @examples
+#' \dontrun{
+#' model <- model |>
+#'   scorch_layer("fc1", "linear", in_features = 32, out_features = 16) |>
+#'   scorch_layer("act1", "relu") |>
+#'   scorch_dropout("drop1", p = 0.3)
+#' }
+#'
+#' @family model construction
+#'
+#' @export
+
+scorch_dropout <- function(scorch_model,
+                           name,
+                           inputs = NULL,
+                           p = 0.5,
+                           ...) {
+
+  do_mod <- torch::nn_dropout(p = p, ...)
+
+  #- Resolve inputs when not specified explicitly.
+
+  if (is.null(inputs)) {
+
+    if (nrow(scorch_model$graph) == 0) {
+
+      if (length(scorch_model$inputs) != 1) {
+
+        stop("Must specify 'inputs' when multiple inputs exist.",
+             call. = FALSE)
+      }
+
+      inputs <- scorch_model$inputs
+
+    } else {
+
+      inputs <- tail(scorch_model$graph$name, 1)
+    }
+  }
+
+  #- Append to graph.
+
+  scorch_model$graph <- tibble::add_row(
+
+    scorch_model$graph,
+    name   = name,
+    module = list(do_mod),
+    inputs = list(inputs)
+  )
+
+  scorch_model
+}
+
+#=== END =======================================================================

--- a/R/scorch_dropout.R
+++ b/R/scorch_dropout.R
@@ -67,7 +67,7 @@ scorch_dropout <- function(scorch_model,
 
     } else {
 
-      inputs <- tail(scorch_model$graph$name, 1)
+      inputs <- utils::tail(scorch_model$graph$name, 1)
     }
   }
 

--- a/R/scorch_dropout.R
+++ b/R/scorch_dropout.R
@@ -13,8 +13,14 @@
 #' @param scorch_model A \code{scorch_model} object created by
 #'   \code{\link{initiate_scorch}}.
 #'
-#' @param name A single character string giving a unique name for this
-#'   node in the computation graph.
+#' @param name A unique character string identifying this node in the
+#'   model graph. Names wire the computation graph -- other nodes
+#'   reference them via their \code{inputs} argument to define
+#'   branching, fusion, and skip connections. Names are arbitrary but
+#'   appear in error messages and \code{\link{plot_scorch_model}}
+#'   output. Common prefixes: \code{"fc"} (linear), \code{"conv"}
+#'   (convolution), \code{"act"} (activation). Use number suffixes
+#'   for multiples (e.g., \code{"fc1"}, \code{"fc2"}).
 #'
 #' @param inputs Character vector of upstream node names. If \code{NULL}
 #'   (default), resolved automatically (last node or sole input).

--- a/R/scorch_embeddings.R
+++ b/R/scorch_embeddings.R
@@ -17,7 +17,7 @@
 #' @param scale A scaling factor applied to the input before creating the
 #' embedding. Default is 1.0.
 #'
-#' @return A `SinusoidalEmbedding` object.
+#' @returns A `SinusoidalEmbedding` object.
 #'
 #' @examples
 #'
@@ -26,6 +26,8 @@
 #' emb <- SinusoidalEmbedding(8)
 #'
 #' emb(x)
+#'
+#' @family embeddings
 #'
 #' @export
 #'
@@ -67,7 +69,7 @@ SinusoidalEmbedding <- nn_module(
 #'
 #' @param scale A scaling factor applied to the input. Default is 1.0.
 #'
-#' @return A `LinearEmbedding` object.
+#' @returns A `LinearEmbedding` object.
 #'
 #' @examples
 #'
@@ -76,6 +78,8 @@ SinusoidalEmbedding <- nn_module(
 #' emb <- LinearEmbedding(8)
 #'
 #' emb(x)
+#'
+#' @family embeddings
 #'
 #' @export
 
@@ -106,7 +110,7 @@ LinearEmbedding <- nn_module(
 #'
 #' @param size The dimension of the embedding.
 #'
-#' @return A `LearnableEmbedding` object.
+#' @returns A `LearnableEmbedding` object.
 #'
 #' @examples
 #'
@@ -115,6 +119,8 @@ LinearEmbedding <- nn_module(
 #' emb <- LearnableEmbedding(8)
 #'
 #' emb(x)
+#'
+#' @family embeddings
 #'
 #' @export
 
@@ -140,7 +146,7 @@ LearnableEmbedding <- nn_module(
 #' The `IdentityEmbedding` module applies an identity transformation,
 #' effectively passing the input through without modification.
 #'
-#' @return An `IdentityEmbedding` object.
+#' @returns An `IdentityEmbedding` object.
 #'
 #' @examples
 #'
@@ -149,6 +155,8 @@ LearnableEmbedding <- nn_module(
 #' emb <- IdentityEmbedding()
 #'
 #' emb(x)
+#'
+#' @family embeddings
 #'
 #' @export
 
@@ -169,7 +177,7 @@ IdentityEmbedding <- nn_module(
 #' The `ZeroEmbedding` module generates a zero-valued embedding of the same
 #' size as the input, essentially nullifying the input data.
 #'
-#' @return A `ZeroEmbedding` object.
+#' @returns A `ZeroEmbedding` object.
 #'
 #' @examples
 #'
@@ -178,6 +186,8 @@ IdentityEmbedding <- nn_module(
 #' emb <- ZeroEmbedding()
 #'
 #' emb(x)
+#'
+#' @family embeddings
 #'
 #' @export
 
@@ -205,7 +215,7 @@ ZeroEmbedding <- nn_module(
 #'
 #' @param ... Additional parameters specific to the chosen embedding type.
 #'
-#' @return A `PositionalEmbedding` object.
+#' @returns A `PositionalEmbedding` object.
 #'
 #' @examples
 #'
@@ -216,6 +226,8 @@ ZeroEmbedding <- nn_module(
 #' emb(x)
 #'
 #' @references <https://github.com/tanelp/tiny-diffusion>
+#'
+#' @family embeddings
 #'
 #' @export
 
@@ -245,7 +257,7 @@ PositionalEmbedding <- nn_module(
 
     } else {
 
-      stop("Unknown positional embedding type: ", type)
+      stop("Unknown positional embedding type: ", type, call. = FALSE)
     }
   },
 

--- a/R/scorch_transformer_encoder.R
+++ b/R/scorch_transformer_encoder.R
@@ -14,8 +14,14 @@
 #' @param scorch_model A \code{scorch_model} object created by
 #'   \code{\link{initiate_scorch}}.
 #'
-#' @param name A single character string giving a unique name for this
-#'   node in the computation graph.
+#' @param name A unique character string identifying this node in the
+#'   model graph. Names wire the computation graph -- other nodes
+#'   reference them via their \code{inputs} argument to define
+#'   branching, fusion, and skip connections. Names are arbitrary but
+#'   appear in error messages and \code{\link{plot_scorch_model}}
+#'   output. Common prefixes: \code{"fc"} (linear), \code{"conv"}
+#'   (convolution), \code{"act"} (activation). Use number suffixes
+#'   for multiples (e.g., \code{"fc1"}, \code{"fc2"}).
 #'
 #' @param inputs Character vector of a single upstream node name.
 #'

--- a/R/scorch_transformer_encoder.R
+++ b/R/scorch_transformer_encoder.R
@@ -1,0 +1,86 @@
+#===============================================================================
+# FUNCTION TO ADD A TRANSFORMER ENCODER LAYER TO A SCORCH MODEL
+#===============================================================================
+
+#=== MAIN FUNCTION =============================================================
+
+#' Add a Transformer Encoder Layer to a Scorch Model
+#'
+#' @description
+#' Adds a \code{torch::nn_transformer_encoder_layer} node to the
+#' Scorch model graph. Implements one layer of the standard
+#' transformer encoder (self-attention + feed-forward).
+#'
+#' @param scorch_model A \code{scorch_model} object created by
+#'   \code{\link{initiate_scorch}}.
+#'
+#' @param name A single character string giving a unique name for this
+#'   node in the computation graph.
+#'
+#' @param inputs Character vector of a single upstream node name.
+#'
+#' @param embed_dim Integer. The d_model dimension (total embedding
+#'   size).
+#'
+#' @param num_heads Integer. Number of attention heads.
+#'
+#' @param dim_feedforward Integer. Dimension of the feed-forward
+#'   network (default 2048).
+#'
+#' @param dropout Numeric. Dropout rate (default 0.1).
+#'
+#' @param ... Additional arguments passed to
+#'   \code{torch::nn_transformer_encoder_layer()}.
+#'
+#' @returns The updated \code{scorch_model} with a new row appended to
+#'   its \code{graph} tibble.
+#'
+#' @details
+#' The \code{embed_dim} must be divisible by \code{num_heads}. This
+#' adds a single encoder layer; stack multiple calls for deeper
+#' transformers.
+#'
+#' @examples
+#' \dontrun{
+#' # Two-layer transformer encoder
+#' model <- model |>
+#'   scorch_transformer_encoder("enc1", inputs = "embeddings",
+#'                              embed_dim = 64, num_heads = 4) |>
+#'   scorch_transformer_encoder("enc2", inputs = "enc1",
+#'                              embed_dim = 64, num_heads = 4)
+#' }
+#'
+#' @family model construction
+#'
+#' @export
+
+scorch_transformer_encoder <- function(scorch_model,
+                                       name,
+                                       inputs,
+                                       embed_dim,
+                                       num_heads,
+                                       dim_feedforward = 2048,
+                                       dropout = 0.1,
+                                       ...) {
+
+  tr_mod <- torch::nn_transformer_encoder_layer(
+
+    d_model         = embed_dim,
+    nhead           = num_heads,
+    dim_feedforward = dim_feedforward,
+    dropout         = dropout,
+    ...
+  )
+
+  scorch_model$graph <- tibble::add_row(
+
+    scorch_model$graph,
+    name   = name,
+    module = list(tr_mod),
+    inputs = list(inputs)
+  )
+
+  scorch_model
+}
+
+#=== END =======================================================================


### PR DESCRIPTION
Adds convenience functions for common graph operations, model inspection methods and Roxygen documentation for existing files. Depends on PR3 (architecture rewrite).

**New node helpers:**

1. `scorch_concat()` -- concatenates upstream tensors along a dimension (for fusion)
2. `scorch_add_skip()` -- element-wise addition of two tensors (residual/skip connections, replaces old use_residual argument)
3. `scorch_batchnorm()` -- convenience wrapper for nn_batch_norm1d
4. `scorch_dropout()` -- convenience wrapper for nn_dropout
5. `scorch_attention()` -- multi-head attention node (query, key, value inputs)
6. `scorch_transformer_encoder()` -- single transformer encoder layer

**New methods:**

7. `print.scorch_model()` -- displays graph summary table; works before and after compilation; `detailed = TRUE` shows weight dimensions
8. `plot_scorch_model()` -- renders computation graph as Graphviz diagram via `DiagrammeR` package

**Roxygen doc cleanup (no logic changes):**

9. `scorch_embeddings.R` 
10. `scorch_diffusion.R`

**DESCRIPTION:** Adds `dplyr` to Imports, `DiagrammeR` to Suggests. Removes unused `glue`, `stringr`. Adds `utils::globalVariables()` for `dplyr` NSE compliance.

All files pass devtools::check() with 0 errors, 0 warnings.